### PR TITLE
Avro 1.12 support with MODEL$ and simplified logical type handling

### DIFF
--- a/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
+++ b/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
@@ -52,6 +52,30 @@ private[avro2s] object LogicalTypes {
       val key = LogicalTypeKey(schemaType, logicalTypeName)
       logicalTypeMap.get(key).exists(_.validate(schema))
     }
+
+    def getConversionClass(schema: Schema): Option[String] = {
+      Option(schema.getLogicalType).flatMap { logicalType =>
+        val key = LogicalTypeKey(schema.getType, logicalType.getName)
+        logicalTypeMap.get(key).filter(_.validate(schema)).map(_.conversionClass)
+      }
+    }
+
+    def toTypeAcceptBoth(schema: Schema, value: String): String = {
+      Option(schema.getLogicalType).map { logicalType =>
+        val key = LogicalTypeKey(schema.getType, logicalType.getName)
+        logicalTypeMap.get(key) match {
+          case Some(lt) if lt.validate(schema) => lt.toTypeAcceptBoth(value, schema)
+          case _ => value
+        }
+      }.getOrElse(value)
+    }
+
+    def logicalReceiveType(schema: Schema): Option[String] = {
+      Option(schema.getLogicalType).flatMap { logicalType =>
+        val key = LogicalTypeKey(schema.getType, logicalType.getName)
+        logicalTypeMap.get(key).filter(_.validate(schema)).map(_.getType(schema))
+      }
+    }
     
     def getDefault(schema: Schema): String = Option(schema.getLogicalType).map { logicalType =>
       val schemaType = schema.getType
@@ -72,8 +96,29 @@ private[avro2s] object LogicalTypes {
     def getType(schema: Schema): String
 
     def validate(schema: Schema): Boolean = true
-    
+
     def defaultValue(schema: Schema): String
+
+    def conversionClass: String
+
+    def toTypeAcceptBoth(value: String, schema: Schema): String = {
+      val castedX = schema.getType match {
+        case STRING => "x.toString"
+        case _ => s"x.asInstanceOf[${primitiveScalaType(schema.getType)}]"
+      }
+      s"($value match { case x: ${getType(schema)} => x; case x => ${toType(castedX, schema)} })"
+    }
+
+    private def primitiveScalaType(schemaType: Type): String = schemaType match {
+      case INT => "Int"
+      case LONG => "Long"
+      case FLOAT => "Float"
+      case DOUBLE => "Double"
+      case BOOLEAN => "Boolean"
+      case STRING => "String"
+      case BYTES => "Array[Byte]"
+      case _ => "Any"
+    }
   }
 
   case object UUID extends LogicalType("uuid", Set(STRING)) {
@@ -84,6 +129,8 @@ private[avro2s] object LogicalTypes {
     override def getType(schema: Schema): String = "java.util.UUID"
 
     override def defaultValue(schema: Schema): String = "java.util.UUID.fromString(\"00000000-0000-0000-0000-000000000000\")"
+
+    override def conversionClass: String = "org.apache.avro.Conversions.UUIDConversion"
   }
 
   case object Date extends LogicalType("date", Set(INT)) {
@@ -94,6 +141,8 @@ private[avro2s] object LogicalTypes {
     override def getType(schema: Schema): String = "java.time.LocalDate"
 
     override def defaultValue(schema: Schema): String = "java.time.LocalDate.ofEpochDay(0)"
+
+    override def conversionClass: String = "org.apache.avro.data.TimeConversions.DateConversion"
   }
 
   case object TimeMillisecondPrecision extends LogicalType("time-millis", Set(INT)) {
@@ -104,6 +153,8 @@ private[avro2s] object LogicalTypes {
     override def getType(schema: Schema): String = "java.time.LocalTime"
 
     override def defaultValue(schema: Schema): String = "java.time.LocalTime.ofNanoOfDay(0)"
+
+    override def conversionClass: String = "org.apache.avro.data.TimeConversions.TimeMillisConversion"
   }
 
   case object TimeMicrosecondPrecision extends LogicalType("time-micros", Set(LONG)) {
@@ -114,6 +165,8 @@ private[avro2s] object LogicalTypes {
     override def getType(schema: Schema): String = "java.time.LocalTime"
 
     override def defaultValue(schema: Schema): String = "java.time.LocalTime.ofNanoOfDay(0)"
+
+    override def conversionClass: String = "org.apache.avro.data.TimeConversions.TimeMicrosConversion"
   }
 
   case object TimestampMillisecondPrecision extends LogicalType("timestamp-millis", Set(LONG)) {
@@ -124,6 +177,8 @@ private[avro2s] object LogicalTypes {
     override def getType(schema: Schema): String = "java.time.Instant"
 
     override def defaultValue(schema: Schema): String = "java.time.Instant.ofEpochMilli(0)"
+
+    override def conversionClass: String = "org.apache.avro.data.TimeConversions.TimestampMillisConversion"
   }
 
   case object TimestampMicrosecondPrecision extends LogicalType("timestamp-micros", Set(LONG)) {
@@ -134,6 +189,8 @@ private[avro2s] object LogicalTypes {
     override def getType(schema: Schema): String = "java.time.Instant"
 
     override def defaultValue(schema: Schema): String = "java.time.Instant.ofEpochSecond(0, 0)"
+
+    override def conversionClass: String = "org.apache.avro.data.TimeConversions.TimestampMicrosConversion"
   }
 
   case object LocalTimestampMillisecondPrecision extends LogicalType("local-timestamp-millis", Set(LONG)) {
@@ -144,6 +201,8 @@ private[avro2s] object LogicalTypes {
     override def getType(schema: Schema): String = "java.time.LocalDateTime"
 
     override def defaultValue(schema: Schema): String = "java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of(\"UTC\"))"
+
+    override def conversionClass: String = "org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion"
   }
 
   case object LocalTimestampMicrosecondPrecision extends LogicalType("local-timestamp-micros", Set(LONG)) {
@@ -154,6 +213,8 @@ private[avro2s] object LogicalTypes {
     override def getType(schema: Schema): String = "java.time.LocalDateTime"
 
     override def defaultValue(schema: Schema): String = "java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(0, 0), java.time.ZoneId.of(\"UTC\"))"
+
+    override def conversionClass: String = "org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion"
   }
 
   // TODO: implement decimal
@@ -165,6 +226,8 @@ private[avro2s] object LogicalTypes {
     override def getType(schema: Schema): String = ???
 
     override def defaultValue(schema: Schema): String = ???
+
+    override def conversionClass: String = ???
   }
 
   // TODO: Implement duration
@@ -178,6 +241,8 @@ private[avro2s] object LogicalTypes {
     override def validate(schema: Schema): Boolean = schema.getFixedSize == 12
 
     override def defaultValue(schema: Schema): String = ???
+
+    override def conversionClass: String = ???
   }
 
   private val supportedLogicalTypes: List[LogicalType] = List(

--- a/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
+++ b/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
@@ -228,6 +228,4 @@ private[avro2s] object LogicalTypes {
         LogicalTypeKey(at, lt.name) -> lt
       }
     }.toMap
-
-  val allConversionClasses: List[String] = supportedLogicalTypes.map(_.conversionClass).distinct
 }

--- a/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
+++ b/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
@@ -117,7 +117,7 @@ private[avro2s] object LogicalTypes {
       case BOOLEAN => "Boolean"
       case STRING => "String"
       case BYTES => "Array[Byte]"
-      case _ => "Any"
+      case t => throw new IllegalArgumentException(s"Unsupported primitive type: $t")
     }
   }
 

--- a/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
+++ b/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
@@ -228,4 +228,6 @@ private[avro2s] object LogicalTypes {
         LogicalTypeKey(at, lt.name) -> lt
       }
     }.toMap
+
+  val allConversionClasses: List[String] = supportedLogicalTypes.map(_.conversionClass).distinct
 }

--- a/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
+++ b/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
@@ -60,6 +60,19 @@ private[avro2s] object LogicalTypes {
       }
     }
 
+    /** Recursively collects all distinct conversion class names referenced within a schema,
+     *  including those nested inside MAP values, ARRAY items, and UNION branches.
+     */
+    def collectConversionClasses(schema: Schema): List[String] = {
+      import scala.jdk.CollectionConverters._
+      schema.getType match {
+        case Schema.Type.MAP   => collectConversionClasses(schema.getValueType)
+        case Schema.Type.ARRAY => collectConversionClasses(schema.getElementType)
+        case Schema.Type.UNION => schema.getTypes.asScala.toList.flatMap(collectConversionClasses)
+        case _                 => getConversionClass(schema).toList
+      }
+    }
+
     def getDefault(schema: Schema): String = Option(schema.getLogicalType).map { logicalType =>
       val schemaType = schema.getType
       val logicalTypeName = logicalType.getName

--- a/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
+++ b/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
@@ -60,23 +60,6 @@ private[avro2s] object LogicalTypes {
       }
     }
 
-    def toTypeAcceptBoth(schema: Schema, value: String): String = {
-      Option(schema.getLogicalType).map { logicalType =>
-        val key = LogicalTypeKey(schema.getType, logicalType.getName)
-        logicalTypeMap.get(key) match {
-          case Some(lt) if lt.validate(schema) => lt.toTypeAcceptBoth(value, schema)
-          case _ => value
-        }
-      }.getOrElse(value)
-    }
-
-    def logicalReceiveType(schema: Schema): Option[String] = {
-      Option(schema.getLogicalType).flatMap { logicalType =>
-        val key = LogicalTypeKey(schema.getType, logicalType.getName)
-        logicalTypeMap.get(key).filter(_.validate(schema)).map(_.getType(schema))
-      }
-    }
-    
     def getDefault(schema: Schema): String = Option(schema.getLogicalType).map { logicalType =>
       val schemaType = schema.getType
       val logicalTypeName = logicalType.getName
@@ -100,25 +83,6 @@ private[avro2s] object LogicalTypes {
     def defaultValue(schema: Schema): String
 
     def conversionClass: String
-
-    def toTypeAcceptBoth(value: String, schema: Schema): String = {
-      val castedX = schema.getType match {
-        case STRING => "x.toString"
-        case _ => s"x.asInstanceOf[${primitiveScalaType(schema.getType)}]"
-      }
-      s"($value match { case x: ${getType(schema)} => x; case x => ${toType(castedX, schema)} })"
-    }
-
-    private def primitiveScalaType(schemaType: Type): String = schemaType match {
-      case INT => "Int"
-      case LONG => "Long"
-      case FLOAT => "Float"
-      case DOUBLE => "Double"
-      case BOOLEAN => "Boolean"
-      case STRING => "String"
-      case BYTES => "Array[Byte]"
-      case t => throw new IllegalArgumentException(s"Unsupported primitive type: $t")
-    }
   }
 
   case object UUID extends LogicalType("uuid", Set(STRING)) {

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/fixed/SpecificFixedGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/fixed/SpecificFixedGenerator.scala
@@ -37,8 +37,8 @@ private[avro2s] object SpecificFixedGenerator {
       .add(s"object $name {")
       .indent
       .add(s"""val SCHEMA$$ = new org.apache.avro.Schema.Parser().parse(\"\"\"${schema.toString}\"\"\")""")
-      .add(s"val READER$$ = new org.apache.avro.specific.SpecificDatumReader[$name]($name.SCHEMA$$)")
-      .add(s"val WRITER$$ = new org.apache.avro.specific.SpecificDatumWriter[$name]($name.SCHEMA$$)")
+      .add(s"val READER$$ = new org.apache.avro.specific.SpecificDatumReader[$name]($name.SCHEMA$$, $name.SCHEMA$$, new org.apache.avro.specific.SpecificData())")
+      .add(s"val WRITER$$ = new org.apache.avro.specific.SpecificDatumWriter[$name]($name.SCHEMA$$, new org.apache.avro.specific.SpecificData())")
       .add(s"def apply(data: Array[Byte]): $name = {")
       .indent
       .add(s"val fixed = new $nsPrefix$name()")

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/GetCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/GetCaseGenerator.scala
@@ -113,13 +113,13 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
           .add("}")
           .outdent
           .add("}.toBuffer).asJava")
-      case BYTES =>
+      case BYTES if !ltc.logicalTypeInUse(schema.getElementType) =>
         printer
           .add("scala.jdk.CollectionConverters.BufferHasAsJava({")
           .indent
           .add(s"$value.map { bytes =>")
           .indent
-          .add(ltc.fromTypeWithFallback(schema.getElementType, "bytes", "java.nio.ByteBuffer.wrap(bytes)"))
+          .add("java.nio.ByteBuffer.wrap(bytes)")
           .outdent
           .add("}")
           .outdent
@@ -130,7 +130,7 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
           .indent
           .add(s"$value.map { x =>")
           .indent
-          .add(s"${ltc.fromType(schema.getElementType, "x")}.asInstanceOf[AnyRef]")
+          .add(s"x.asInstanceOf[AnyRef]")
           .outdent
           .add("}")
           .outdent
@@ -166,12 +166,12 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
       case ARRAY =>
         printer
           .call(printArrayValue(_, schema, Some("kvp._2")))
-      case BYTES =>
+      case BYTES if !ltc.logicalTypeInUse(schema) =>
         printer
-          .add(ltc.fromTypeWithFallback(schema, value, s"java.nio.ByteBuffer.wrap($value)"))
+          .add(s"java.nio.ByteBuffer.wrap($value)")
       case _ =>
         printer
-          .add(ltc.fromType(schema, value))
+          .add(s"$value.asInstanceOf[AnyRef]")
     }
   }
 
@@ -189,8 +189,8 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
         case UNION => s"\n${printUnionPatternMatch(new FunctionalPrinter(indentLevel = 1), unionSchemasToType(schemas(schema))).result()}"
         case ARRAY if schema.getElementType.isUnion => s"\nscala.jdk.CollectionConverters.BufferHasAsJava({\n  x.map {${x(schema.getElementType)}\n  }\n}.toBuffer).asJava.asInstanceOf[AnyRef]"
         case ARRAY => s"\nscala.jdk.CollectionConverters.BufferHasAsJava({\n  x.map { x =>${x(schema.getElementType)}\n  }\n}.toBuffer).asJava.asInstanceOf[AnyRef]"
-        case BYTES => ltc.fromTypeWithFallback(schema, "x", s"\njava.nio.ByteBuffer.wrap(x).asInstanceOf[AnyRef]")
-        case _ => s"${ltc.fromType(schema, "x")}.asInstanceOf[AnyRef]"
+        case BYTES if !ltc.logicalTypeInUse(schema) => s"\njava.nio.ByteBuffer.wrap(x).asInstanceOf[AnyRef]"
+        case _ => s"x.asInstanceOf[AnyRef]"
       }
     }
 

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/GetCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/GetCaseGenerator.scala
@@ -71,8 +71,11 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
       .add(s"case $index => ${ltc.fromTypeWithFallback(field.schema(), field.safeName, s"java.nio.ByteBuffer.wrap(${field.safeName})")}.asInstanceOf[AnyRef]")
 
   private def printDefaultCase(printer: FunctionalPrinter, index: Int, field: Schema.Field): FunctionalPrinter =
-    printer
-      .add(s"case $index => ${ltc.fromType(field.schema(), s"${field.safeName}")}.asInstanceOf[AnyRef]")
+    if (ltc.getConversionClass(field.schema()).isDefined) {
+      printer.add(s"case $index => ${field.safeName}.asInstanceOf[AnyRef]")
+    } else {
+      printer.add(s"case $index => ${ltc.fromType(field.schema(), s"${field.safeName}")}.asInstanceOf[AnyRef]")
+    }
 
   private def printArrayValue(printer: FunctionalPrinter, schema: Schema, valueName: Option[String] = None): FunctionalPrinter = {
     val value = valueName.getOrElse("array")

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/GetCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/GetCaseGenerator.scala
@@ -71,7 +71,7 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
       .add(s"case $index => ${ltc.fromTypeWithFallback(field.schema(), field.safeName, s"java.nio.ByteBuffer.wrap(${field.safeName})")}.asInstanceOf[AnyRef]")
 
   private def printDefaultCase(printer: FunctionalPrinter, index: Int, field: Schema.Field): FunctionalPrinter =
-    if (ltc.getConversionClass(field.schema()).isDefined) {
+    if (ltc.logicalTypeInUse(field.schema())) {
       printer.add(s"case $index => ${field.safeName}.asInstanceOf[AnyRef]")
     } else {
       printer.add(s"case $index => ${ltc.fromType(field.schema(), s"${field.safeName}")}.asInstanceOf[AnyRef]")

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/PutCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/PutCaseGenerator.scala
@@ -55,9 +55,14 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
         printer
           .add(s"case $index => this.${field.safeName} = ${ltc.toTypeWithFallback(field.schema(), value, fallback)}")
       case _ =>
-        val value = s"${toStringConverter("value", field.schema())}.asInstanceOf[${schemaToScalaType(field.schema, false)}]"
-        printer
-          .add(s"case $index => this.${field.safeName} = ${ltc.toType(field.schema(), value)}")
+        if (ltc.getConversionClass(field.schema()).isDefined) {
+          printer
+            .add(s"case $index => this.${field.safeName} = value.asInstanceOf[${ltc.getType(field.schema(), schemaToScalaType(field.schema, false))}]")
+        } else {
+          val value = s"${toStringConverter("value", field.schema())}.asInstanceOf[${schemaToScalaType(field.schema, false)}]"
+          printer
+            .add(s"case $index => this.${field.safeName} = ${ltc.toType(field.schema(), value)}")
+        }
     }
   }
 
@@ -124,8 +129,11 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
           .outdent
           .add("}")
       case _ =>
-        printer
-          .add(ltc.toType(schema, typeCast(valueName, schema)))
+        if (ltc.logicalTypeInUse(schema)) {
+          printer.add(ltc.toTypeAcceptBoth(schema, valueName))
+        } else {
+          printer.add(ltc.toType(schema, typeCast(valueName, schema)))
+        }
     }
   }
 
@@ -157,42 +165,48 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
         printer
           .call(matchBytes(_, "value", schema))
       case _ =>
-        printer
-          .add(ltc.toType(schema, typeCast("value", schema)))
+        if (ltc.logicalTypeInUse(schema)) {
+          printer.add(ltc.toTypeAcceptBoth(schema, "value"))
+        } else {
+          printer.add(ltc.toType(schema, typeCast("value", schema)))
+        }
     }
   }
 
   private def matchUnionInner(printer: FunctionalPrinter, union: UnionRepresentation): FunctionalPrinter = {
     union match {
       case CoproductRepresentation(types) => printer.add({
-        types.map { t =>
+        types.flatMap { t =>
           t.getType match {
-            case RECORD | ENUM => s"case x: ${t.getFullName} => Coproduct[${union.asString(typeHelpers)}](x)"
+            case RECORD | ENUM => List(s"case x: ${t.getFullName} => Coproduct[${union.asString(typeHelpers)}](x)")
             case MAP =>
-              new FunctionalPrinter()
+              List(new FunctionalPrinter()
                 .add(s"case map: java.util.Map[_,_] => Coproduct[${union.asString(typeHelpers)}]{")
                 .indent
                 .call(printMapValue(_, t))
                 .outdent
                 .add("}")
-                .result()
-            case FIXED => s"case x: ${t.getFullName} => Coproduct[${union.asString(typeHelpers)}](${ltc.toType(t, "x")})"
-            case BYTES => s"case x: java.nio.ByteBuffer => Coproduct[${union.asString(typeHelpers)}](${ltc.toTypeWithFallback(t, "x", "x.array()")})"
+                .result())
+            case FIXED => List(s"case x: ${t.getFullName} => Coproduct[${union.asString(typeHelpers)}](${ltc.toType(t, "x")})")
+            case BYTES => List(s"case x: java.nio.ByteBuffer => Coproduct[${union.asString(typeHelpers)}](${ltc.toTypeWithFallback(t, "x", "x.array()")})")
             case ARRAY =>
-              new FunctionalPrinter()
+              List(new FunctionalPrinter()
                 .add(s"case x: java.util.List[_] => Coproduct[${union.asString(typeHelpers)}]({")
                 .indent
                 .call(printArrayValue(_, "x", t))
                 .outdent
                 .add("}.toList)")
-                .result()
+                .result())
             case _ =>
               val typeName = simpleTypeToScalaReceiveType(t.getType)
               val x = toStringConverter("x", t)
               val `case` = if (t.getType == Type.NULL) "x @ null" else s"x: $typeName"
-              s"case ${`case`} => Coproduct[${union.asString(typeHelpers)}](${ltc.toType(t, x)})"
+              val logicalCase = ltc.logicalReceiveType(t).map { lrt =>
+                s"case x: $lrt => Coproduct[${union.asString(typeHelpers)}](x)"
+              }.toList
+              logicalCase :+ s"case ${`case`} => Coproduct[${union.asString(typeHelpers)}](${ltc.toType(t, x)})"
           }
-        } :+ "case _ => throw new AvroRuntimeException(\"Invalid value\")"
+        } :+ "case _ => throw new AvroRuntimeException(\"Unexpected type: \" + value.getClass.getName)"
       }.mkString("\n"))
       case OptionRepresentation(schema) =>
         val nullCasePrinter = printer.add("case null => None")
@@ -223,7 +237,10 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
           case _ =>
             val x = toStringConverter("x", schema)
             val xCase = Try(s"x: ${simpleTypeToScalaReceiveType(schema.getType)}").getOrElse("x")
-            nullCasePrinter
+            val withLogicalCase = ltc.logicalReceiveType(schema).map { lrt =>
+              nullCasePrinter.add(s"case x: $lrt => Some(x)")
+            }.getOrElse(nullCasePrinter)
+            withLogicalCase
               .add(s"case $xCase => Some(${ltc.toType(schema, x)})")
         }
     }

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/PutCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/PutCaseGenerator.scala
@@ -55,7 +55,7 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
         printer
           .add(s"case $index => this.${field.safeName} = ${ltc.toTypeWithFallback(field.schema(), value, fallback)}")
       case _ =>
-        if (ltc.getConversionClass(field.schema()).isDefined) {
+        if (ltc.logicalTypeInUse(field.schema())) {
           printer
             .add(s"case $index => this.${field.safeName} = value.asInstanceOf[${ltc.getType(field.schema(), schemaToScalaType(field.schema, false))}]")
         } else {

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/PutCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/PutCaseGenerator.scala
@@ -130,7 +130,7 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
           .add("}")
       case _ =>
         if (ltc.logicalTypeInUse(schema)) {
-          printer.add(ltc.toTypeAcceptBoth(schema, valueName))
+          printer.add(s"$valueName.asInstanceOf[${ltc.getType(schema, schemaToScalaType(schema, false))}]")
         } else {
           printer.add(ltc.toType(schema, typeCast(valueName, schema)))
         }
@@ -166,7 +166,7 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
           .call(matchBytes(_, "value", schema))
       case _ =>
         if (ltc.logicalTypeInUse(schema)) {
-          printer.add(ltc.toTypeAcceptBoth(schema, "value"))
+          printer.add(s"value.asInstanceOf[${ltc.getType(schema, schemaToScalaType(schema, false))}]")
         } else {
           printer.add(ltc.toType(schema, typeCast("value", schema)))
         }
@@ -198,13 +198,14 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
                 .add("}.toList)")
                 .result())
             case _ =>
-              val typeName = simpleTypeToScalaReceiveType(t.getType)
-              val x = toStringConverter("x", t)
-              val `case` = if (t.getType == Type.NULL) "x @ null" else s"x: $typeName"
-              val logicalCase = ltc.logicalReceiveType(t).map { lrt =>
-                s"case x: $lrt => Coproduct[${union.asString(typeHelpers)}](x)"
-              }.toList
-              logicalCase :+ s"case ${`case`} => Coproduct[${union.asString(typeHelpers)}](${ltc.toType(t, x)})"
+              if (ltc.logicalTypeInUse(t)) {
+                List(s"case x: ${ltc.getType(t, simpleTypeToScalaReceiveType(t.getType))} => Coproduct[${union.asString(typeHelpers)}](x)")
+              } else {
+                val typeName = simpleTypeToScalaReceiveType(t.getType)
+                val x = toStringConverter("x", t)
+                val `case` = if (t.getType == Type.NULL) "x @ null" else s"x: $typeName"
+                List(s"case ${`case`} => Coproduct[${union.asString(typeHelpers)}](${ltc.toType(t, x)})")
+              }
           }
         } :+ "case _ => throw new AvroRuntimeException(\"Unexpected type: \" + value.getClass.getName)"
       }.mkString("\n"))
@@ -235,13 +236,13 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
             nullCasePrinter
               .add(s"case x: ${schema.getFullName} => Some(${ltc.toType(schema, "x")})")
           case _ =>
-            val x = toStringConverter("x", schema)
-            val xCase = Try(s"x: ${simpleTypeToScalaReceiveType(schema.getType)}").getOrElse("x")
-            val withLogicalCase = ltc.logicalReceiveType(schema).map { lrt =>
-              nullCasePrinter.add(s"case x: $lrt => Some(x)")
-            }.getOrElse(nullCasePrinter)
-            withLogicalCase
-              .add(s"case $xCase => Some(${ltc.toType(schema, x)})")
+            if (ltc.logicalTypeInUse(schema)) {
+              nullCasePrinter.add(s"case x: ${ltc.getType(schema, simpleTypeToScalaReceiveType(schema.getType))} => Some(x)")
+            } else {
+              val x = toStringConverter("x", schema)
+              val xCase = Try(s"x: ${simpleTypeToScalaReceiveType(schema.getType)}").getOrElse("x")
+              nullCasePrinter.add(s"case $xCase => Some(${ltc.toType(schema, x)})")
+            }
         }
     }
   }

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
@@ -113,7 +113,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   private def printModel(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
     if (!generatorConfig.logicalTypesEnabled) printer
     else {
-      val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
+      val distinctConversions = fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
       printer
         .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
         .indent
@@ -131,8 +131,9 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
     if (!generatorConfig.logicalTypesEnabled) printer
     else {
-      val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
-      distinctConversions.foldLeft(printer) { (p, cls) =>
+      val distinctConversions = fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
+      if (distinctConversions.isEmpty) printer
+      else distinctConversions.foldLeft(printer) { (p, cls) =>
         val shortName = cls.split('.').last
         p.add(s"val $dollar$shortName: org.apache.avro.Conversion[_] = new $cls()")
       }

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
@@ -40,6 +40,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .when(schema.getFields.toArray.length > 0)(_.add(toThis(fields)))
       .newline
       .add(s"override def getSchema: org.apache.avro.Schema = $name.SCHEMA$dollar")
+      .when(generatorConfig.logicalTypesEnabled)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
       .newline
       .add("override def get(field$: Int): AnyRef = {")
       .indent
@@ -73,6 +74,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add(s"object $name {")
       .indent
       .add(s"""val SCHEMA$dollar: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"\"\"${schema.toString}\"\"\")""")
+      .call(printModel(_))
       .call(printConversionVals(_, fields))
       .outdent
       .add("}")
@@ -100,6 +102,21 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add("}")
       .outdent
       .add("}")
+  }
+
+  private def printModel(printer: FunctionalPrinter): FunctionalPrinter = {
+    if (!generatorConfig.logicalTypesEnabled) printer
+    else {
+      val conversions = LogicalTypes.allConversionClasses
+      printer
+        .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
+        .indent
+        .add("val model = new org.apache.avro.specific.SpecificData()")
+        .add(conversions.map(cls => s"model.addLogicalTypeConversion(new $cls())"): _*)
+        .add("model")
+        .outdent
+        .add("}")
+    }
   }
 
   private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
@@ -129,10 +129,13 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   }
 
   private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
-    val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
-    distinctConversions.foldLeft(printer) { (p, cls) =>
-      val shortName = cls.split('.').last
-      p.add(s"val $dollar$shortName: org.apache.avro.Conversion[_] = new $cls()")
+    if (!generatorConfig.logicalTypesEnabled) printer
+    else {
+      val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
+      distinctConversions.foldLeft(printer) { (p, cls) =>
+        val shortName = cls.split('.').last
+        p.add(s"val $dollar$shortName: org.apache.avro.Conversion[_] = new $cls()")
+      }
     }
   }
 

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
@@ -45,8 +45,8 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .indent
       .add("(field$: @switch) match {")
       .indent
-      .print(fields) { (printer, field) =>
-        getCaseGenerator.printFieldCase(printer, fields.indexOf(field), field)
+      .print(fields.zipWithIndex) { case (printer, (field, idx)) =>
+        getCaseGenerator.printFieldCase(printer, idx, field)
       }
       .add("case _ => throw new org.apache.avro.AvroRuntimeException(\"Bad index\")")
       .outdent
@@ -58,41 +58,40 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .indent
       .add("(field$: @switch) match {")
       .indent
-      .print(fields) { (printer, field) =>
-        putCaseGenerator.printFieldCase(printer, fields.indexOf(field), field)
+      .print(fields.zipWithIndex) { case (printer, (field, idx)) =>
+        putCaseGenerator.printFieldCase(printer, idx, field)
       }
       .add("case _ => throw new org.apache.avro.AvroRuntimeException(\"Bad index\")")
       .outdent
       .add("}")
       .outdent
       .add("}")
-      .call(printGetConversion(_, fields))
+      .call(printGetConversion(_, name, fields))
       .outdent
       .add("}")
       .newline
       .add(s"object $name {")
       .indent
       .add(s"""val SCHEMA$dollar: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"\"\"${schema.toString}\"\"\")""")
+      .call(printConversionVals(_, fields))
       .outdent
       .add("}")
 
     GeneratedCode(s"${ns.map(_.replace(".", "/") + "/").getOrElse("") + name}.scala", code.result())
   }
 
-  private def printGetConversion(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
+  private def printGetConversion(printer: FunctionalPrinter, name: String, fields: List[Schema.Field]): FunctionalPrinter = {
     val hasAnyConversion = fields.exists(f => ltc.getConversionClass(f.schema()).isDefined)
-    if (!hasAnyConversion) return printer
-
-    printer
+    if (!hasAnyConversion) printer
+    else printer
       .newline
       .add("override def getConversion(field: Int): org.apache.avro.Conversion[_] = {")
       .indent
       .add("(field: @switch) match {")
       .indent
-      .print(fields) { (p, field) =>
-        val idx = fields.indexOf(field)
+      .print(fields.zipWithIndex) { case (p, (field, idx)) =>
         ltc.getConversionClass(field.schema()) match {
-          case Some(cls) => p.add(s"case $idx => new $cls()")
+          case Some(_) => p.add(s"case $idx => $name.${field.safeName}$$Conversion")
           case None => p.add(s"case $idx => null")
         }
       }
@@ -101,6 +100,15 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add("}")
       .outdent
       .add("}")
+  }
+
+  private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
+    fields.foldLeft(printer) { (p, field) =>
+      ltc.getConversionClass(field.schema()) match {
+        case Some(cls) => p.add(s"val ${field.safeName}$$Conversion: org.apache.avro.Conversion[_] = new $cls()")
+        case None => p
+      }
+    }
   }
 
   private def fieldsToParams(fields: List[Schema.Field]): String = {

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
@@ -66,6 +66,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add("}")
       .outdent
       .add("}")
+      .call(printGetConversion(_, fields))
       .outdent
       .add("}")
       .newline
@@ -76,6 +77,30 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add("}")
 
     GeneratedCode(s"${ns.map(_.replace(".", "/") + "/").getOrElse("") + name}.scala", code.result())
+  }
+
+  private def printGetConversion(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
+    val hasAnyConversion = fields.exists(f => ltc.getConversionClass(f.schema()).isDefined)
+    if (!hasAnyConversion) return printer
+
+    printer
+      .newline
+      .add("override def getConversion(field: Int): org.apache.avro.Conversion[_] = {")
+      .indent
+      .add("(field: @switch) match {")
+      .indent
+      .print(fields) { (p, field) =>
+        val idx = fields.indexOf(field)
+        ltc.getConversionClass(field.schema()) match {
+          case Some(cls) => p.add(s"case $idx => new $cls()")
+          case None => p.add(s"case $idx => null")
+        }
+      }
+      .add("case _ => null")
+      .outdent
+      .add("}")
+      .outdent
+      .add("}")
   }
 
   private def fieldsToParams(fields: List[Schema.Field]): String = {

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
@@ -23,6 +23,9 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
     val fields = schema.getFields.asScala.toList
     val ns = Option(schema.getNamespace).orElse(namespace)
     val nsString = ns.getOrElse("")
+    val distinctConversions =
+      if (!generatorConfig.logicalTypesEnabled) Nil
+      else fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
 
     val functionalPrinter = new FunctionalPrinter()
 
@@ -40,7 +43,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .when(schema.getFields.toArray.length > 0)(_.add(toThis(fields)))
       .newline
       .add(s"override def getSchema: org.apache.avro.Schema = $name.SCHEMA$dollar")
-      .when(generatorConfig.logicalTypesEnabled)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
+      .when(distinctConversions.nonEmpty)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
       .newline
       .add("override def get(field$: Int): AnyRef = {")
       .indent
@@ -74,8 +77,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add(s"object $name {")
       .indent
       .add(s"""val SCHEMA$dollar: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"\"\"${schema.toString}\"\"\")""")
-      .call(printConversionVals(_, fields))
-      .call(printModel(_, fields))
+      .call(printConversionInfrastructure(_, distinctConversions))
       .outdent
       .add("}")
 
@@ -110,34 +112,23 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
     }
   }
 
-  private def printModel(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
-    if (!generatorConfig.logicalTypesEnabled) printer
-    else {
-      val distinctConversions = fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
-      printer
-        .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
-        .indent
-        .add("val model = new org.apache.avro.specific.SpecificData()")
-        .add(distinctConversions.map { cls =>
-          val shortName = cls.split('.').last
-          s"model.addLogicalTypeConversion($dollar$shortName)"
-        }: _*)
-        .add("model")
-        .outdent
-        .add("}")
-    }
-  }
-
-  private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
-    if (!generatorConfig.logicalTypesEnabled) printer
-    else {
-      val distinctConversions = fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
-      if (distinctConversions.isEmpty) printer
-      else distinctConversions.foldLeft(printer) { (p, cls) =>
+  private def printConversionInfrastructure(printer: FunctionalPrinter, distinctConversions: List[String]): FunctionalPrinter = {
+    if (distinctConversions.isEmpty) printer
+    else distinctConversions
+      .foldLeft(printer) { (p, cls) =>
         val shortName = cls.split('.').last
         p.add(s"val $dollar$shortName: org.apache.avro.Conversion[_] = new $cls()")
       }
-    }
+      .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
+      .indent
+      .add("val model = new org.apache.avro.specific.SpecificData()")
+      .add(distinctConversions.map { cls =>
+        val shortName = cls.split('.').last
+        s"model.addLogicalTypeConversion($dollar$shortName)"
+      }: _*)
+      .add("model")
+      .outdent
+      .add("}")
   }
 
   private def fieldsToParams(fields: List[Schema.Field]): String = {

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
@@ -74,8 +74,8 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add(s"object $name {")
       .indent
       .add(s"""val SCHEMA$dollar: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"\"\"${schema.toString}\"\"\")""")
-      .call(printModel(_))
       .call(printConversionVals(_, fields))
+      .call(printModel(_, fields))
       .outdent
       .add("}")
 
@@ -83,36 +83,45 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   }
 
   private def printGetConversion(printer: FunctionalPrinter, name: String, fields: List[Schema.Field]): FunctionalPrinter = {
-    val hasAnyConversion = fields.exists(f => ltc.getConversionClass(f.schema()).isDefined)
-    if (!hasAnyConversion) printer
-    else printer
-      .newline
-      .add("override def getConversion(field: Int): org.apache.avro.Conversion[_] = {")
-      .indent
-      .add("(field: @switch) match {")
-      .indent
-      .print(fields.zipWithIndex) { case (p, (field, idx)) =>
-        ltc.getConversionClass(field.schema()) match {
-          case Some(_) => p.add(s"case $idx => $name.${field.safeName}$$Conversion")
-          case None => p.add(s"case $idx => null")
-        }
-      }
-      .add("case _ => null")
-      .outdent
-      .add("}")
-      .outdent
-      .add("}")
-  }
-
-  private def printModel(printer: FunctionalPrinter): FunctionalPrinter = {
     if (!generatorConfig.logicalTypesEnabled) printer
     else {
-      val conversions = LogicalTypes.allConversionClasses
+      val hasAnyConversion = fields.exists(f => ltc.logicalTypeInUse(f.schema()))
+      if (!hasAnyConversion) printer
+      else printer
+        .newline
+        .add("override def getConversion(field: Int): org.apache.avro.Conversion[_] = {")
+        .indent
+        .add("(field: @switch) match {")
+        .indent
+        .print(fields.zipWithIndex) { case (p, (field, idx)) =>
+          ltc.getConversionClass(field.schema()) match {
+            case Some(cls) =>
+              val shortName = cls.split('.').last
+              p.add(s"case $idx => $name.$dollar$shortName")
+            case None =>
+              p.add(s"case $idx => null")
+          }
+        }
+        .add("case _ => null")
+        .outdent
+        .add("}")
+        .outdent
+        .add("}")
+    }
+  }
+
+  private def printModel(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
+    if (!generatorConfig.logicalTypesEnabled) printer
+    else {
+      val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
       printer
         .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
         .indent
         .add("val model = new org.apache.avro.specific.SpecificData()")
-        .add(conversions.map(cls => s"model.addLogicalTypeConversion(new $cls())"): _*)
+        .add(distinctConversions.map { cls =>
+          val shortName = cls.split('.').last
+          s"model.addLogicalTypeConversion($dollar$shortName)"
+        }: _*)
         .add("model")
         .outdent
         .add("}")
@@ -120,11 +129,10 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   }
 
   private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
-    fields.foldLeft(printer) { (p, field) =>
-      ltc.getConversionClass(field.schema()) match {
-        case Some(cls) => p.add(s"val ${field.safeName}$$Conversion: org.apache.avro.Conversion[_] = new $cls()")
-        case None => p
-      }
+    val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
+    distinctConversions.foldLeft(printer) { (p, cls) =>
+      val shortName = cls.split('.').last
+      p.add(s"val $dollar$shortName: org.apache.avro.Conversion[_] = new $cls()")
     }
   }
 

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/GetCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/GetCaseGenerator.scala
@@ -98,16 +98,16 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
               .add(s"$input.map { m =>")
               .indent
               .call(printMapValue(_, schema.getElementType, "m"))
-          case BYTES =>
+          case BYTES if !ltc.logicalTypeInUse(schema.getElementType) =>
             printer
               .add(s"$input.map { bytes =>")
               .indent
-              .add(ltc.fromTypeWithFallback(schema.getElementType, "bytes", "java.nio.ByteBuffer.wrap(bytes)"))
+              .add("java.nio.ByteBuffer.wrap(bytes)")
           case _ =>
             printer
               .add(s"$input.map { x =>")
               .indent
-              .add(s"${ltc.fromType(schema.getElementType, "x")}.asInstanceOf[AnyRef]")
+              .add(s"x.asInstanceOf[AnyRef]")
         }
       })
       .outdent
@@ -143,12 +143,12 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
       case ARRAY =>
         printer
           .call(printArrayValue(_, schema, "kvp._2"))
-      case BYTES =>
+      case BYTES if !ltc.logicalTypeInUse(schema) =>
         printer
-          .add(ltc.fromTypeWithFallback(schema, input, s"java.nio.ByteBuffer.wrap($input)"))
+          .add(s"java.nio.ByteBuffer.wrap($input)")
       case _ =>
         printer
-          .add(ltc.fromType(schema, input))
+          .add(s"$input.asInstanceOf[AnyRef]")
     }
   }
 
@@ -159,8 +159,8 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
         case UNION => s"\n${printUnionPatternMatch(new FunctionalPrinter(indentLevel = 1), TypeUnion(schemas(schema))).result()}"
         case ARRAY if schema.getElementType.isUnion => s"\nscala.jdk.CollectionConverters.BufferHasAsJava({\n  x.map {${x(schema.getElementType)}\n  }\n}.toBuffer).asJava.asInstanceOf[AnyRef]"
         case ARRAY => s"\nscala.jdk.CollectionConverters.BufferHasAsJava({\n  x.map { x =>${x(schema.getElementType)}\n  }\n}.toBuffer).asJava.asInstanceOf[AnyRef]"
-        case BYTES => ltc.fromTypeWithFallback(schema, "x", s"\njava.nio.ByteBuffer.wrap(x).asInstanceOf[AnyRef]")
-        case _ => s"${ltc.fromType(schema, "x")}.asInstanceOf[AnyRef]"
+        case BYTES if !ltc.logicalTypeInUse(schema) => s"\njava.nio.ByteBuffer.wrap(x).asInstanceOf[AnyRef]"
+        case _ => s"x.asInstanceOf[AnyRef]"
       }
     }
 

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/GetCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/GetCaseGenerator.scala
@@ -71,8 +71,11 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
       .add(s"case $index => ${ltc.fromTypeWithFallback(field.schema(), field.safeName, s"java.nio.ByteBuffer.wrap(${field.safeName})")}.asInstanceOf[AnyRef]")
 
   private def printDefaultCase(printer: FunctionalPrinter, index: Int, field: Schema.Field): FunctionalPrinter =
-    printer
-      .add(s"case $index => ${ltc.fromType(field.schema(), s"${field.safeName}")}.asInstanceOf[AnyRef]")
+    if (ltc.getConversionClass(field.schema()).isDefined) {
+      printer.add(s"case $index => ${field.safeName}.asInstanceOf[AnyRef]")
+    } else {
+      printer.add(s"case $index => ${ltc.fromType(field.schema(), s"${field.safeName}")}.asInstanceOf[AnyRef]")
+    }
 
   private def printArrayValue(printer: FunctionalPrinter, schema: Schema, input: String): FunctionalPrinter = {
     printer

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/GetCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/GetCaseGenerator.scala
@@ -71,7 +71,7 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
       .add(s"case $index => ${ltc.fromTypeWithFallback(field.schema(), field.safeName, s"java.nio.ByteBuffer.wrap(${field.safeName})")}.asInstanceOf[AnyRef]")
 
   private def printDefaultCase(printer: FunctionalPrinter, index: Int, field: Schema.Field): FunctionalPrinter =
-    if (ltc.getConversionClass(field.schema()).isDefined) {
+    if (ltc.logicalTypeInUse(field.schema())) {
       printer.add(s"case $index => ${field.safeName}.asInstanceOf[AnyRef]")
     } else {
       printer.add(s"case $index => ${ltc.fromType(field.schema(), s"${field.safeName}")}.asInstanceOf[AnyRef]")

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/PutCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/PutCaseGenerator.scala
@@ -106,7 +106,7 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
           .call(asBytes(_, input, schema))
       case _ =>
         if (ltc.logicalTypeInUse(schema)) {
-          printer.add(ltc.toTypeAcceptBoth(schema, input))
+          printer.add(s"$input.asInstanceOf[${ltc.getType(schema, schemaToScalaType(schema, false))}]")
         } else {
           printer.add(ltc.toType(schema, typeCast(input, schema)))
         }
@@ -136,18 +136,16 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
                 .outdent
                 .result())
             case _ =>
-              t.getType match {
-                case Type.STRING =>
-                  val logicalCase = ltc.logicalReceiveType(t).map { lrt =>
-                    s"case x: $lrt => ${union.toConstructString("x")}"
-                  }.toList
-                  logicalCase :+ s"case x: org.apache.avro.util.Utf8 => ${union.toConstructString(ltc.toType(t, "x.toString"))}"
-                case Type.NULL => List(s"case null => None")
-                case _ =>
-                  val logicalCase = ltc.logicalReceiveType(t).map { lrt =>
-                    s"case x: $lrt => ${union.toConstructString("x")}"
-                  }.toList
-                  logicalCase :+ s"case x: ${simpleTypeToScalaReceiveType(t.getType)} => ${union.toConstructString(ltc.toType(t, "x"))}"
+              if (ltc.logicalTypeInUse(t)) {
+                List(s"case x: ${ltc.getType(t, simpleTypeToScalaReceiveType(t.getType))} => ${union.toConstructString("x")}")
+              } else {
+                t.getType match {
+                  case Type.STRING =>
+                    List(s"case x: org.apache.avro.util.Utf8 => ${union.toConstructString(ltc.toType(t, "x.toString"))}")
+                  case Type.NULL => List(s"case null => None")
+                  case _ =>
+                    List(s"case x: ${simpleTypeToScalaReceiveType(t.getType)} => ${union.toConstructString(ltc.toType(t, "x"))}")
+                }
               }
           }
         } :+ "case _ => throw new org.apache.avro.AvroRuntimeException(\"Unexpected type: \" + value.getClass.getName)"
@@ -184,7 +182,7 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
           .call(asBytes(_, "value", schema))
       case _ =>
         if (ltc.logicalTypeInUse(schema)) {
-          printer.add(ltc.toTypeAcceptBoth(schema, "value"))
+          printer.add(s"value.asInstanceOf[${ltc.getType(schema, schemaToScalaType(schema, false))}]")
         } else {
           printer.add(ltc.toType(schema, typeCast("value", schema)))
         }

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/PutCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/PutCaseGenerator.scala
@@ -77,9 +77,12 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
   }
 
   private def asDefault(printer: FunctionalPrinter, input: String, schema: Schema): FunctionalPrinter = {
-    val value = s"${toStringConverter(input, schema)}.asInstanceOf[${schemaToScalaType(schema, false)}]"
-    printer
-      .add(s"${ltc.toType(schema, value)}")
+    if (ltc.getConversionClass(schema).isDefined) {
+      printer.add(s"$input.asInstanceOf[${ltc.getType(schema, schemaToScalaType(schema, false))}]")
+    } else {
+      val value = s"${toStringConverter(input, schema)}.asInstanceOf[${schemaToScalaType(schema, false)}]"
+      printer.add(s"${ltc.toType(schema, value)}")
+    }
   }
 
   private def assignArray(printer: FunctionalPrinter, input: String, schema: Schema): FunctionalPrinter = {
@@ -102,38 +105,49 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
         printer
           .call(asBytes(_, input, schema))
       case _ =>
-        printer
-          .add(ltc.toType(schema, typeCast(input, schema)))
+        if (ltc.logicalTypeInUse(schema)) {
+          printer.add(ltc.toTypeAcceptBoth(schema, input))
+        } else {
+          printer.add(ltc.toType(schema, typeCast(input, schema)))
+        }
     }
   }
 
   private def matchUnionType(printer: FunctionalPrinter, union: TypeUnion): FunctionalPrinter = {
     union match {
       case TypeUnion(types) => printer.add({
-        types.map { t =>
+        types.flatMap { t =>
           t.getType match {
-            case RECORD | ENUM => s"case x: ${t.getFullName} => ${union.toConstructString(s"x.asInstanceOf[${union.innerTypeStr(typeHelpers)}]")}"
-            case FIXED => s"case x: ${t.getFullName} => ${union.toConstructString(s"${ltc.toType(t, "x")}.asInstanceOf[${union.innerTypeStr(typeHelpers)}]")}"
+            case RECORD | ENUM => List(s"case x: ${t.getFullName} => ${union.toConstructString(s"x.asInstanceOf[${union.innerTypeStr(typeHelpers)}]")}")
+            case FIXED => List(s"case x: ${t.getFullName} => ${union.toConstructString(s"${ltc.toType(t, "x")}.asInstanceOf[${union.innerTypeStr(typeHelpers)}]")}")
             case MAP =>
-              new FunctionalPrinter()
+              List(new FunctionalPrinter()
                 .add(s"case map: java.util.Map[?,?] =>")
                 .indent
                 .add(s"${union.toConstructString(assignMap(new FunctionalPrinter(), "map", t).result())}")
                 .outdent
-                .result()
-            case BYTES => s"case x: java.nio.ByteBuffer => ${union.toConstructString(ltc.toTypeWithFallback(t, "x", "x.array()"))}"
+                .result())
+            case BYTES => List(s"case x: java.nio.ByteBuffer => ${union.toConstructString(ltc.toTypeWithFallback(t, "x", "x.array()"))}")
             case ARRAY =>
-              new FunctionalPrinter()
+              List(new FunctionalPrinter()
                 .add(s"case array: java.util.List[?] =>")
                 .indent
                 .add(s"${union.toConstructString(assignArray(new FunctionalPrinter(), "array", t).result())}")
                 .outdent
-                .result()
+                .result())
             case _ =>
               t.getType match {
-                case Type.STRING => s"case x: org.apache.avro.util.Utf8 => ${union.toConstructString(ltc.toType(t, "x.toString"))}"
-                case Type.NULL => s"case null => None"
-                case _ => s"case x: ${simpleTypeToScalaReceiveType(t.getType)} => ${union.toConstructString(ltc.toType(t, "x"))}"
+                case Type.STRING =>
+                  val logicalCase = ltc.logicalReceiveType(t).map { lrt =>
+                    s"case x: $lrt => ${union.toConstructString("x")}"
+                  }.toList
+                  logicalCase :+ s"case x: org.apache.avro.util.Utf8 => ${union.toConstructString(ltc.toType(t, "x.toString"))}"
+                case Type.NULL => List(s"case null => None")
+                case _ =>
+                  val logicalCase = ltc.logicalReceiveType(t).map { lrt =>
+                    s"case x: $lrt => ${union.toConstructString("x")}"
+                  }.toList
+                  logicalCase :+ s"case x: ${simpleTypeToScalaReceiveType(t.getType)} => ${union.toConstructString(ltc.toType(t, "x"))}"
               }
           }
         } :+ "case _ => throw new org.apache.avro.AvroRuntimeException(\"Unexpected type: \" + value.getClass.getName)"
@@ -169,8 +183,11 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
         printer
           .call(asBytes(_, "value", schema))
       case _ =>
-        printer
-          .add(ltc.toType(schema, typeCast("value", schema)))
+        if (ltc.logicalTypeInUse(schema)) {
+          printer.add(ltc.toTypeAcceptBoth(schema, "value"))
+        } else {
+          printer.add(ltc.toType(schema, typeCast("value", schema)))
+        }
     }
   }
 }

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/PutCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/PutCaseGenerator.scala
@@ -77,7 +77,7 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
   }
 
   private def asDefault(printer: FunctionalPrinter, input: String, schema: Schema): FunctionalPrinter = {
-    if (ltc.getConversionClass(schema).isDefined) {
+    if (ltc.logicalTypeInUse(schema)) {
       printer.add(s"$input.asInstanceOf[${ltc.getType(schema, schemaToScalaType(schema, false))}]")
     } else {
       val value = s"${toStringConverter(input, schema)}.asInstanceOf[${schemaToScalaType(schema, false)}]"

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
@@ -37,6 +37,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .when(schema.getFields.toArray.length > 0)(_.add(toThis(fields)))
       .newline
       .add(s"override def getSchema: org.apache.avro.Schema = $name.SCHEMA$dollar")
+      .when(generatorConfig.logicalTypesEnabled)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
       .newline
       .add("override def get(field$: Int): AnyRef = {")
       .indent
@@ -70,6 +71,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add(s"object $name {")
       .indent
       .add(s"""val SCHEMA$dollar: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"\"\"${schema.toString}\"\"\")""")
+      .call(printModel(_))
       .call(printConversionVals(_, fields))
       .outdent
       .add("}")
@@ -97,6 +99,21 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add("}")
       .outdent
       .add("}")
+  }
+
+  private def printModel(printer: FunctionalPrinter): FunctionalPrinter = {
+    if (!generatorConfig.logicalTypesEnabled) printer
+    else {
+      val conversions = LogicalTypes.allConversionClasses
+      printer
+        .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
+        .indent
+        .add("val model = new org.apache.avro.specific.SpecificData()")
+        .add(conversions.map(cls => s"model.addLogicalTypeConversion(new $cls())"): _*)
+        .add("model")
+        .outdent
+        .add("}")
+    }
   }
 
   private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
@@ -63,6 +63,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add("}")
       .outdent
       .add("}")
+      .call(printGetConversion(_, fields))
       .outdent
       .add("}")
       .newline
@@ -73,6 +74,30 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add("}")
 
     GeneratedCode(s"${ns.map(_.replace(".", "/") + "/").getOrElse("") + name}.scala", code.result())
+  }
+
+  private def printGetConversion(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
+    val hasAnyConversion = fields.exists(f => ltc.getConversionClass(f.schema()).isDefined)
+    if (!hasAnyConversion) return printer
+
+    printer
+      .newline
+      .add("override def getConversion(field: Int): org.apache.avro.Conversion[?] = {")
+      .indent
+      .add("(field: @switch) match {")
+      .indent
+      .print(fields) { (p, field) =>
+        val idx = fields.indexOf(field)
+        ltc.getConversionClass(field.schema()) match {
+          case Some(cls) => p.add(s"case $idx => new $cls()")
+          case None => p.add(s"case $idx => null")
+        }
+      }
+      .add("case _ => null")
+      .outdent
+      .add("}")
+      .outdent
+      .add("}")
   }
 
   private def fieldsToParams(fields: List[Schema.Field]): String = {

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
@@ -22,6 +22,9 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
     val fields = schema.getFields.asScala.toList
     val ns = Option(schema.getNamespace).orElse(namespace)
     val nsString = ns.getOrElse("")
+    val distinctConversions =
+      if (!generatorConfig.logicalTypesEnabled) Nil
+      else fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
 
     val functionalPrinter = new FunctionalPrinter()
 
@@ -37,7 +40,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .when(schema.getFields.toArray.length > 0)(_.add(toThis(fields)))
       .newline
       .add(s"override def getSchema: org.apache.avro.Schema = $name.SCHEMA$dollar")
-      .when(generatorConfig.logicalTypesEnabled)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
+      .when(distinctConversions.nonEmpty)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
       .newline
       .add("override def get(field$: Int): AnyRef = {")
       .indent
@@ -71,8 +74,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add(s"object $name {")
       .indent
       .add(s"""val SCHEMA$dollar: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"\"\"${schema.toString}\"\"\")""")
-      .call(printConversionVals(_, fields))
-      .call(printModel(_, fields))
+      .call(printConversionInfrastructure(_, distinctConversions))
       .outdent
       .add("}")
 
@@ -107,34 +109,23 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
     }
   }
 
-  private def printModel(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
-    if (!generatorConfig.logicalTypesEnabled) printer
-    else {
-      val distinctConversions = fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
-      printer
-        .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
-        .indent
-        .add("val model = new org.apache.avro.specific.SpecificData()")
-        .add(distinctConversions.map { cls =>
-          val shortName = cls.split('.').last
-          s"model.addLogicalTypeConversion($dollar$shortName)"
-        }: _*)
-        .add("model")
-        .outdent
-        .add("}")
-    }
-  }
-
-  private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
-    if (!generatorConfig.logicalTypesEnabled) printer
-    else {
-      val distinctConversions = fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
-      if (distinctConversions.isEmpty) printer
-      else distinctConversions.foldLeft(printer) { (p, cls) =>
+  private def printConversionInfrastructure(printer: FunctionalPrinter, distinctConversions: List[String]): FunctionalPrinter = {
+    if (distinctConversions.isEmpty) printer
+    else distinctConversions
+      .foldLeft(printer) { (p, cls) =>
         val shortName = cls.split('.').last
         p.add(s"val $dollar$shortName: org.apache.avro.Conversion[?] = new $cls()")
       }
-    }
+      .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
+      .indent
+      .add("val model = new org.apache.avro.specific.SpecificData()")
+      .add(distinctConversions.map { cls =>
+        val shortName = cls.split('.').last
+        s"model.addLogicalTypeConversion($dollar$shortName)"
+      }: _*)
+      .add("model")
+      .outdent
+      .add("}")
   }
 
   private def fieldsToParams(fields: List[Schema.Field]): String = {

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
@@ -71,8 +71,8 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add(s"object $name {")
       .indent
       .add(s"""val SCHEMA$dollar: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"\"\"${schema.toString}\"\"\")""")
-      .call(printModel(_))
       .call(printConversionVals(_, fields))
+      .call(printModel(_, fields))
       .outdent
       .add("}")
 
@@ -80,36 +80,45 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   }
 
   private def printGetConversion(printer: FunctionalPrinter, name: String, fields: List[Schema.Field]): FunctionalPrinter = {
-    val hasAnyConversion = fields.exists(f => ltc.getConversionClass(f.schema()).isDefined)
-    if (!hasAnyConversion) printer
-    else printer
-      .newline
-      .add("override def getConversion(field: Int): org.apache.avro.Conversion[?] = {")
-      .indent
-      .add("(field: @switch) match {")
-      .indent
-      .print(fields.zipWithIndex) { case (p, (field, idx)) =>
-        ltc.getConversionClass(field.schema()) match {
-          case Some(_) => p.add(s"case $idx => $name.${field.safeName}$$Conversion")
-          case None => p.add(s"case $idx => null")
-        }
-      }
-      .add("case _ => null")
-      .outdent
-      .add("}")
-      .outdent
-      .add("}")
-  }
-
-  private def printModel(printer: FunctionalPrinter): FunctionalPrinter = {
     if (!generatorConfig.logicalTypesEnabled) printer
     else {
-      val conversions = LogicalTypes.allConversionClasses
+      val hasAnyConversion = fields.exists(f => ltc.logicalTypeInUse(f.schema()))
+      if (!hasAnyConversion) printer
+      else printer
+        .newline
+        .add("override def getConversion(field: Int): org.apache.avro.Conversion[?] = {")
+        .indent
+        .add("(field: @switch) match {")
+        .indent
+        .print(fields.zipWithIndex) { case (p, (field, idx)) =>
+          ltc.getConversionClass(field.schema()) match {
+            case Some(cls) =>
+              val shortName = cls.split('.').last
+              p.add(s"case $idx => $name.$dollar$shortName")
+            case None =>
+              p.add(s"case $idx => null")
+          }
+        }
+        .add("case _ => null")
+        .outdent
+        .add("}")
+        .outdent
+        .add("}")
+    }
+  }
+
+  private def printModel(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
+    if (!generatorConfig.logicalTypesEnabled) printer
+    else {
+      val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
       printer
         .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
         .indent
         .add("val model = new org.apache.avro.specific.SpecificData()")
-        .add(conversions.map(cls => s"model.addLogicalTypeConversion(new $cls())"): _*)
+        .add(distinctConversions.map { cls =>
+          val shortName = cls.split('.').last
+          s"model.addLogicalTypeConversion($dollar$shortName)"
+        }: _*)
         .add("model")
         .outdent
         .add("}")
@@ -117,10 +126,12 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   }
 
   private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
-    fields.foldLeft(printer) { (p, field) =>
-      ltc.getConversionClass(field.schema()) match {
-        case Some(cls) => p.add(s"val ${field.safeName}$$Conversion: org.apache.avro.Conversion[?] = new $cls()")
-        case None => p
+    if (!generatorConfig.logicalTypesEnabled) printer
+    else {
+      val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
+      distinctConversions.foldLeft(printer) { (p, cls) =>
+        val shortName = cls.split('.').last
+        p.add(s"val $dollar$shortName: org.apache.avro.Conversion[?] = new $cls()")
       }
     }
   }

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
@@ -110,7 +110,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   private def printModel(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
     if (!generatorConfig.logicalTypesEnabled) printer
     else {
-      val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
+      val distinctConversions = fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
       printer
         .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
         .indent
@@ -128,8 +128,9 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
     if (!generatorConfig.logicalTypesEnabled) printer
     else {
-      val distinctConversions = fields.flatMap(f => ltc.getConversionClass(f.schema())).distinct
-      distinctConversions.foldLeft(printer) { (p, cls) =>
+      val distinctConversions = fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
+      if (distinctConversions.isEmpty) printer
+      else distinctConversions.foldLeft(printer) { (p, cls) =>
         val shortName = cls.split('.').last
         p.add(s"val $dollar$shortName: org.apache.avro.Conversion[?] = new $cls()")
       }

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
@@ -42,8 +42,8 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .indent
       .add("(field$: @switch) match {")
       .indent
-      .print(fields) { (printer, field) =>
-        getCaseGenerator.printFieldCase(printer, fields.indexOf(field), field)
+      .print(fields.zipWithIndex) { case (printer, (field, idx)) =>
+        getCaseGenerator.printFieldCase(printer, idx, field)
       }
       .add("case _ => throw new org.apache.avro.AvroRuntimeException(\"Bad index\")")
       .outdent
@@ -55,41 +55,40 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .indent
       .add("(field$: @switch) match {")
       .indent
-      .print(fields) { (printer, field) =>
-        putCaseGenerator.printFieldCase(printer, fields.indexOf(field), field)
+      .print(fields.zipWithIndex) { case (printer, (field, idx)) =>
+        putCaseGenerator.printFieldCase(printer, idx, field)
       }
       .add("case _ => throw new org.apache.avro.AvroRuntimeException(\"Bad index\")")
       .outdent
       .add("}")
       .outdent
       .add("}")
-      .call(printGetConversion(_, fields))
+      .call(printGetConversion(_, name, fields))
       .outdent
       .add("}")
       .newline
       .add(s"object $name {")
       .indent
       .add(s"""val SCHEMA$dollar: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"\"\"${schema.toString}\"\"\")""")
+      .call(printConversionVals(_, fields))
       .outdent
       .add("}")
 
     GeneratedCode(s"${ns.map(_.replace(".", "/") + "/").getOrElse("") + name}.scala", code.result())
   }
 
-  private def printGetConversion(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
+  private def printGetConversion(printer: FunctionalPrinter, name: String, fields: List[Schema.Field]): FunctionalPrinter = {
     val hasAnyConversion = fields.exists(f => ltc.getConversionClass(f.schema()).isDefined)
-    if (!hasAnyConversion) return printer
-
-    printer
+    if (!hasAnyConversion) printer
+    else printer
       .newline
       .add("override def getConversion(field: Int): org.apache.avro.Conversion[?] = {")
       .indent
       .add("(field: @switch) match {")
       .indent
-      .print(fields) { (p, field) =>
-        val idx = fields.indexOf(field)
+      .print(fields.zipWithIndex) { case (p, (field, idx)) =>
         ltc.getConversionClass(field.schema()) match {
-          case Some(cls) => p.add(s"case $idx => new $cls()")
+          case Some(_) => p.add(s"case $idx => $name.${field.safeName}$$Conversion")
           case None => p.add(s"case $idx => null")
         }
       }
@@ -98,6 +97,15 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add("}")
       .outdent
       .add("}")
+  }
+
+  private def printConversionVals(printer: FunctionalPrinter, fields: List[Schema.Field]): FunctionalPrinter = {
+    fields.foldLeft(printer) { (p, field) =>
+      ltc.getConversionClass(field.schema()) match {
+        case Some(cls) => p.add(s"val ${field.safeName}$$Conversion: org.apache.avro.Conversion[?] = new $cls()")
+        case None => p
+      }
+    }
   }
 
   private def fieldsToParams(fields: List[Schema.Field]): String = {

--- a/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
@@ -278,15 +278,18 @@ class SerializationTest extends AnyFunSuite with Matchers {
   }
   
   test("logical types can be serialized and deserialized") {
+    val now = java.time.Instant.now()
+    val nowMillis = java.time.Instant.ofEpochMilli(now.toEpochMilli)
+    val nowMicros = java.time.Instant.ofEpochSecond(now.getEpochSecond, (now.getNano / 1000L) * 1000L)
     val logicalTypes = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _time_millis = java.time.LocalTime.ofNanoOfDay((java.time.LocalTime.now().toNanoOfDay / 1000000L) * 1000000L),
+      _time_micros = java.time.LocalTime.ofNanoOfDay((java.time.LocalTime.now().toNanoOfDay / 1000L) * 1000L),
+      _timestamp_millis = nowMillis,
+      _timestamp_micros = nowMicros,
+      _local_timestamp_millis = java.time.LocalDateTime.ofInstant(nowMillis, java.time.ZoneId.of("UTC")),
+      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(nowMicros, java.time.ZoneId.of("UTC"))
     )
 
     deserialize[avro2s.test.logical.LogicalTypes](serialize(logicalTypes), logicalTypes.getSchema) shouldBe logicalTypes
@@ -304,9 +307,9 @@ class SerializationTest extends AnyFunSuite with Matchers {
       _local_timestamp_micros = java.time.LocalDateTime.now().toInstant(java.time.ZoneOffset.UTC).toEpochMilli * 1000
     )
 
-    deserialize[avro2s.test.logical.LogicalTypesDisabled](serialize(logicalTypesDisabled), logicalTypesDisabled.getSchema) shouldBe logicalTypesDisabled
+    deserializeWithoutConversions[avro2s.test.logical.LogicalTypesDisabled](serializeWithoutConversions(logicalTypesDisabled), logicalTypesDisabled.getSchema) shouldBe logicalTypesDisabled
   }
-  
+
   test("logical complex types can be serialized and deserialized") {
     val logicalComplexTypes = avro2s.test.logical.ComplexLogicalTypes(
       _map = Map("a" -> UUID.randomUUID, "c" -> UUID.randomUUID),
@@ -347,8 +350,8 @@ class SerializationTest extends AnyFunSuite with Matchers {
       _array_option = List(Some(UUID.randomUUID.toString), None)
     )
 
-    val serialized = serialize(logicalComplexTypesDisabled)
-    deserialize[avro2s.test.logical.ComplexLogicalTypesDisabled](serialized, logicalComplexTypesDisabled.getSchema) shouldBe logicalComplexTypesDisabled
+    val serialized = serializeWithoutConversions(logicalComplexTypesDisabled)
+    deserializeWithoutConversions[avro2s.test.logical.ComplexLogicalTypesDisabled](serialized, logicalComplexTypesDisabled.getSchema) shouldBe logicalComplexTypesDisabled
   }
   
   test("complex options can be serialized and deserialized") {
@@ -370,6 +373,21 @@ class SerializationTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.unions.ComplexOptions](serialized, complexOptions.getSchema) shouldBe complexOptions
   }
   
+  test("fixed types can be serialized and deserialized standalone") {
+    val data = Array[Byte](0x6f, 0x6e, 0x65, 0x00, 0x74, 0x77, 0x6f, 0x00, 0x74, 0x68, 0x72, 0x65, 0x65, 0x72, 0x65, 0x65)
+    val fixed = avro2s.test.spec.md5(data)
+
+    val out = new java.io.ByteArrayOutputStream()
+    val encoder = org.apache.avro.io.EncoderFactory.get().binaryEncoder(out, null)
+    avro2s.test.spec.md5.WRITER$.write(fixed, encoder)
+    encoder.flush()
+
+    val decoder = org.apache.avro.io.DecoderFactory.get().binaryDecoder(out.toByteArray, null)
+    val result = avro2s.test.spec.md5.READER$.read(null, decoder)
+
+    result.bytes() shouldBe data
+  }
+
   test("empty records can be serialized and deserialized") {
     val emptyRecords = avro2s.test.records.EmptyRecords(
       _string = "foo",

--- a/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
@@ -311,22 +311,23 @@ class SerializationTest extends AnyFunSuite with Matchers {
   }
 
   test("logical complex types can be serialized and deserialized") {
+    def truncateMillis(i: Instant): Instant = Instant.ofEpochMilli(i.toEpochMilli)
     val logicalComplexTypes = avro2s.test.logical.ComplexLogicalTypes(
       _map = Map("a" -> UUID.randomUUID, "c" -> UUID.randomUUID),
       _map_alt = Map("a" -> LocalDate.now, "c" -> LocalDate.now),
       _array = List(LocalDate.now),
-      _union = Coproduct[Int :+: Instant :+: CNil](Instant.now),
+      _union = Coproduct[Int :+: Instant :+: CNil](truncateMillis(Instant.now)),
       _option = Some(UUID.randomUUID),
       _option_alt = Some(LocalDate.now),
-      _map_union = Map("a" -> Coproduct[Int :+: Instant :+: CNil](Instant.now), "c" -> Coproduct[Int :+: Instant :+: CNil](1)),
-      _map_option = Map("a" -> Some(Instant.now), "c" -> None),
+      _map_union = Map("a" -> Coproduct[Int :+: Instant :+: CNil](truncateMillis(Instant.now)), "c" -> Coproduct[Int :+: Instant :+: CNil](1)),
+      _map_option = Map("a" -> Some(truncateMillis(Instant.now)), "c" -> None),
       _map_array = Map("a" -> List(LocalDate.now, LocalDate.now)),
       _union_map = Coproduct[Int :+: Map[String, UUID] :+: CNil](Map("a" -> UUID.randomUUID)),
       _union_map_alt = Coproduct[Int :+: Map[String, LocalDate] :+: CNil](Map("a" -> LocalDate.now)),
       _union_array = Coproduct[Int :+: List[LocalDate] :+: CNil](List(LocalDate.now)),
       _array_map = List(Map("a" -> UUID.randomUUID), Map("e" -> UUID.randomUUID)),
       _array_map_alt = List(Map("a" -> LocalDate.now), Map("e" -> LocalDate.now)),
-      _array_union = List(Coproduct[Int :+: Instant :+: CNil](Instant.now), Coproduct[Int :+: Instant :+: CNil](1)),
+      _array_union = List(Coproduct[Int :+: Instant :+: CNil](truncateMillis(Instant.now)), Coproduct[Int :+: Instant :+: CNil](1)),
       _array_option = List(Some(UUID.randomUUID), None),
       _array_option_alt = List(Some(LocalDate.now), None),
     )

--- a/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
@@ -278,18 +278,15 @@ class SerializationTest extends AnyFunSuite with Matchers {
   }
   
   test("logical types can be serialized and deserialized") {
-    val now = java.time.Instant.now()
-    val nowMillis = java.time.Instant.ofEpochMilli(now.toEpochMilli)
-    val nowMicros = java.time.Instant.ofEpochSecond(now.getEpochSecond, (now.getNano / 1000L) * 1000L)
     val logicalTypes = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.ofNanoOfDay((java.time.LocalTime.now().toNanoOfDay / 1000000L) * 1000000L),
-      _time_micros = java.time.LocalTime.ofNanoOfDay((java.time.LocalTime.now().toNanoOfDay / 1000L) * 1000L),
-      _timestamp_millis = nowMillis,
-      _timestamp_micros = nowMicros,
-      _local_timestamp_millis = java.time.LocalDateTime.ofInstant(nowMillis, java.time.ZoneId.of("UTC")),
-      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(nowMicros, java.time.ZoneId.of("UTC"))
+      _uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+      _date = java.time.LocalDate.of(2009, 2, 13),
+      _time_millis = java.time.LocalTime.ofNanoOfDay(45296123000000L),
+      _time_micros = java.time.LocalTime.ofNanoOfDay(45296123456000L),
+      _timestamp_millis = java.time.Instant.ofEpochMilli(1234567890123L),
+      _timestamp_micros = java.time.Instant.ofEpochSecond(1234567890L, 123456000L),
+      _local_timestamp_millis = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(1234567890123L), java.time.ZoneOffset.UTC),
+      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(1234567890L, 123456000L), java.time.ZoneOffset.UTC)
     )
 
     deserialize[avro2s.test.logical.LogicalTypes](serialize(logicalTypes), logicalTypes.getSchema) shouldBe logicalTypes
@@ -297,39 +294,40 @@ class SerializationTest extends AnyFunSuite with Matchers {
   
   test("logical types disabled can be serialized and deserialized") {
     val logicalTypesDisabled = avro2s.test.logical.LogicalTypesDisabled(
-      _uuid = UUID.randomUUID().toString,
-      _date = java.time.LocalDate.now().toEpochDay.toInt,
-      _time_millis = java.time.LocalTime.now().toNanoOfDay.toInt / 1000000,
-      _time_micros = java.time.LocalTime.now().toNanoOfDay / 1000,
-      _timestamp_millis = java.time.Instant.now().toEpochMilli,
-      _timestamp_micros = java.time.Instant.now().toEpochMilli * 1000,
-      _local_timestamp_millis = java.time.LocalDateTime.now().toInstant(java.time.ZoneOffset.UTC).toEpochMilli,
-      _local_timestamp_micros = java.time.LocalDateTime.now().toInstant(java.time.ZoneOffset.UTC).toEpochMilli * 1000
+      _uuid = "550e8400-e29b-41d4-a716-446655440000",
+      _date = 14288,
+      _time_millis = 45296123,
+      _time_micros = 45296123456L,
+      _timestamp_millis = 1234567890123L,
+      _timestamp_micros = 1234567890123456L,
+      _local_timestamp_millis = 1234567890123L,
+      _local_timestamp_micros = 1234567890123456L
     )
 
     deserializeWithoutConversions[avro2s.test.logical.LogicalTypesDisabled](serializeWithoutConversions(logicalTypesDisabled), logicalTypesDisabled.getSchema) shouldBe logicalTypesDisabled
   }
 
   test("logical complex types can be serialized and deserialized") {
-    def truncateMillis(i: Instant): Instant = Instant.ofEpochMilli(i.toEpochMilli)
+    val ts = Instant.ofEpochMilli(1234567890123L)
+    val date = LocalDate.of(2009, 2, 13)
     val logicalComplexTypes = avro2s.test.logical.ComplexLogicalTypes(
-      _map = Map("a" -> UUID.randomUUID, "c" -> UUID.randomUUID),
-      _map_alt = Map("a" -> LocalDate.now, "c" -> LocalDate.now),
-      _array = List(LocalDate.now),
-      _union = Coproduct[Int :+: Instant :+: CNil](truncateMillis(Instant.now)),
-      _option = Some(UUID.randomUUID),
-      _option_alt = Some(LocalDate.now),
-      _map_union = Map("a" -> Coproduct[Int :+: Instant :+: CNil](truncateMillis(Instant.now)), "c" -> Coproduct[Int :+: Instant :+: CNil](1)),
-      _map_option = Map("a" -> Some(truncateMillis(Instant.now)), "c" -> None),
-      _map_array = Map("a" -> List(LocalDate.now, LocalDate.now)),
-      _union_map = Coproduct[Int :+: Map[String, UUID] :+: CNil](Map("a" -> UUID.randomUUID)),
-      _union_map_alt = Coproduct[Int :+: Map[String, LocalDate] :+: CNil](Map("a" -> LocalDate.now)),
-      _union_array = Coproduct[Int :+: List[LocalDate] :+: CNil](List(LocalDate.now)),
-      _array_map = List(Map("a" -> UUID.randomUUID), Map("e" -> UUID.randomUUID)),
-      _array_map_alt = List(Map("a" -> LocalDate.now), Map("e" -> LocalDate.now)),
-      _array_union = List(Coproduct[Int :+: Instant :+: CNil](truncateMillis(Instant.now)), Coproduct[Int :+: Instant :+: CNil](1)),
-      _array_option = List(Some(UUID.randomUUID), None),
-      _array_option_alt = List(Some(LocalDate.now), None),
+      _map = Map("a" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440000"), "c" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440001")),
+      _map_alt = Map("a" -> date, "c" -> date),
+      _array = List(date),
+      _union = Coproduct[Int :+: Instant :+: CNil](ts),
+      _option = Some(UUID.fromString("550e8400-e29b-41d4-a716-446655440002")),
+      _option_alt = Some(date),
+      _map_union = Map("a" -> Coproduct[Int :+: Instant :+: CNil](ts), "c" -> Coproduct[Int :+: Instant :+: CNil](1)),
+      _map_option = Map("a" -> Some(ts), "c" -> None),
+      _map_array = Map("a" -> List(date, date)),
+      _union_map = Coproduct[Int :+: Map[String, UUID] :+: CNil](Map("a" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440003"))),
+      _union_map_alt = Coproduct[Int :+: Map[String, LocalDate] :+: CNil](Map("a" -> date)),
+      _union_array = Coproduct[Int :+: List[LocalDate] :+: CNil](List(date)),
+      _array_map = List(Map("a" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440004")), Map("e" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440005"))),
+      _array_map_alt = List(Map("a" -> date), Map("e" -> date)),
+      _array_union = List(Coproduct[Int :+: Instant :+: CNil](ts), Coproduct[Int :+: Instant :+: CNil](1)),
+      _array_option = List(Some(UUID.fromString("550e8400-e29b-41d4-a716-446655440006")), None),
+      _array_option_alt = List(Some(date), None),
     )
 
     val serialized = serialize(logicalComplexTypes)
@@ -338,17 +336,17 @@ class SerializationTest extends AnyFunSuite with Matchers {
   
   test("logical complex types disabled can be serialized and deserialized") {
     val logicalComplexTypesDisabled = avro2s.test.logical.ComplexLogicalTypesDisabled(
-      _map = Map("a" -> UUID.randomUUID.toString, "c" -> UUID.randomUUID.toString),
-      _array = List(LocalDate.now.toEpochDay.toInt),
-      _union = Coproduct[Int :+: Long :+: CNil](Instant.now.toEpochMilli),
-      _option = Some(UUID.randomUUID.toString),
-      _map_union = Map("a" -> Coproduct[Int :+: Long :+: CNil](Instant.now.toEpochMilli), "c" -> Coproduct[Int :+: Long :+: CNil](1L)),
-      _map_array = Map("a" -> List(LocalDate.now.toEpochDay.toInt, LocalDate.now.toEpochDay.toInt)),
-      _union_map = Coproduct[Int :+: Map[String, String] :+: CNil](Map("a" -> UUID.randomUUID.toString)),
-      _union_array = Coproduct[Int :+: List[Int] :+: CNil](List(LocalDate.now.toEpochDay.toInt)),
-      _array_map = List(Map("a" -> UUID.randomUUID.toString), Map("e" -> UUID.randomUUID.toString)),
-      _array_union = List(Coproduct[Int :+: Long :+: CNil](Instant.now.toEpochMilli), Coproduct[Int :+: Long :+: CNil](1L)),
-      _array_option = List(Some(UUID.randomUUID.toString), None)
+      _map = Map("a" -> "550e8400-e29b-41d4-a716-446655440000", "c" -> "550e8400-e29b-41d4-a716-446655440001"),
+      _array = List(14288),
+      _union = Coproduct[Int :+: Long :+: CNil](1234567890123L),
+      _option = Some("550e8400-e29b-41d4-a716-446655440002"),
+      _map_union = Map("a" -> Coproduct[Int :+: Long :+: CNil](1234567890123L), "c" -> Coproduct[Int :+: Long :+: CNil](1L)),
+      _map_array = Map("a" -> List(14288, 14288)),
+      _union_map = Coproduct[Int :+: Map[String, String] :+: CNil](Map("a" -> "550e8400-e29b-41d4-a716-446655440003")),
+      _union_array = Coproduct[Int :+: List[Int] :+: CNil](List(14288)),
+      _array_map = List(Map("a" -> "550e8400-e29b-41d4-a716-446655440004"), Map("e" -> "550e8400-e29b-41d4-a716-446655440005")),
+      _array_union = List(Coproduct[Int :+: Long :+: CNil](1234567890123L), Coproduct[Int :+: Long :+: CNil](1L)),
+      _array_option = List(Some("550e8400-e29b-41d4-a716-446655440006"), None)
     )
 
     val serialized = serializeWithoutConversions(logicalComplexTypesDisabled)

--- a/avro2s/src/test/scala-2.13/avro2s/generator/logical/LogicalTypesTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/logical/LogicalTypesTest.scala
@@ -8,71 +8,93 @@ import java.util.UUID
 class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   import avro2s.serialization.SerializationHelpers._
-  
+
+  private def truncateMillis(t: java.time.LocalTime): java.time.LocalTime =
+    java.time.LocalTime.ofNanoOfDay((t.toNanoOfDay / 1000000L) * 1000000L)
+
+  private def truncateMicros(t: java.time.LocalTime): java.time.LocalTime =
+    java.time.LocalTime.ofNanoOfDay((t.toNanoOfDay / 1000L) * 1000L)
+
+  private def truncateMillis(i: java.time.Instant): java.time.Instant =
+    java.time.Instant.ofEpochMilli(i.toEpochMilli)
+
+  private def truncateMicros(i: java.time.Instant): java.time.Instant =
+    java.time.Instant.ofEpochSecond(i.getEpochSecond, (i.getNano / 1000L) * 1000L)
+
+  private def truncateMillisLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
+    java.time.LocalDateTime.ofInstant(truncateMillis(ldt.atZone(java.time.ZoneId.of("UTC")).toInstant), java.time.ZoneId.of("UTC"))
+
+  private def truncateMicrosLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
+    java.time.LocalDateTime.ofInstant(truncateMicros(ldt.atZone(java.time.ZoneId.of("UTC")).toInstant), java.time.ZoneId.of("UTC"))
+
   test("time-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
       _time_millis = time,
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
     val endOfDay = java.time.LocalTime.ofNanoOfDay(86399999999999L)
     startOfDay.format(java.time.format.DateTimeFormatter.ISO_LOCAL_TIME) shouldBe "00:00:00"
     endOfDay.format(java.time.format.DateTimeFormatter.ISO_LOCAL_TIME) shouldBe "23:59:59.999999999"
-    
+
     val start = logicalTypes(startOfDay)
     val end = logicalTypes(endOfDay)
     deserialize[avro2s.test.logical.LogicalTypes](serialize(start), start.getSchema) shouldBe start
-    deserialize[avro2s.test.logical.LogicalTypes](serialize(end), end.getSchema) shouldBe end
-    
-    start.get(2) shouldBe 0
-    end.get(2) shouldBe 86399999
+    // endOfDay has nanosecond precision that gets truncated to millis
+    val endDeserialized = deserialize[avro2s.test.logical.LogicalTypes](serialize(end), end.getSchema)
+    endDeserialized._time_millis shouldBe java.time.LocalTime.ofNanoOfDay(86399999000000L)
+
+    start.get(2).asInstanceOf[java.time.LocalTime] shouldBe startOfDay
+    end.get(2).asInstanceOf[java.time.LocalTime] shouldBe endOfDay
   }
-  
+
   test("time-micros should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
       _time_micros = time,
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
     val endOfDay = java.time.LocalTime.ofNanoOfDay(86399999999999L)
     startOfDay.format(java.time.format.DateTimeFormatter.ISO_LOCAL_TIME) shouldBe "00:00:00"
     endOfDay.format(java.time.format.DateTimeFormatter.ISO_LOCAL_TIME) shouldBe "23:59:59.999999999"
-    
+
     val start = logicalTypes(startOfDay)
     val end = logicalTypes(endOfDay)
     deserialize[avro2s.test.logical.LogicalTypes](serialize(start), start.getSchema) shouldBe start
-    deserialize[avro2s.test.logical.LogicalTypes](serialize(end), end.getSchema) shouldBe end
-    
-    start.get(3) shouldBe 0L
-    end.get(3) shouldBe 86399999999L
+    // endOfDay has nanosecond precision that gets truncated to micros
+    val endDeserialized = deserialize[avro2s.test.logical.LogicalTypes](serialize(end), end.getSchema)
+    endDeserialized._time_micros shouldBe java.time.LocalTime.ofNanoOfDay(86399999999000L)
+
+    start.get(3).asInstanceOf[java.time.LocalTime] shouldBe startOfDay
+    end.get(3).asInstanceOf[java.time.LocalTime] shouldBe endOfDay
   }
-  
+
   test("timestamp-millis should work at the edges") {
     def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
       _timestamp_millis = time,
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfEpoch = java.time.Instant.ofEpochMilli(0)
     val endOfFormatRange = java.time.Instant.ofEpochMilli(253402300799999L)
     val postFormatRange = java.time.Instant.ofEpochMilli(253402300800000L)
@@ -83,7 +105,7 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     postFormatRange.toString shouldBe "+10000-01-01T00:00:00Z"
     upperBound.toString shouldBe "+292278994-08-17T07:12:55.807Z"
     startOfEra.toString shouldBe "0001-01-01T00:00:00Z"
-    
+
     val start = logicalTypes(startOfEpoch)
     val end = logicalTypes(endOfFormatRange)
     val post = logicalTypes(postFormatRange)
@@ -94,26 +116,26 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.logical.LogicalTypes](serialize(post), post.getSchema) shouldBe post
     deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
     deserialize[avro2s.test.logical.LogicalTypes](serialize(era), era.getSchema) shouldBe era
-    
-    start.get(4) shouldBe 0L
-    end.get(4) shouldBe 253402300799999L
-    post.get(4) shouldBe 253402300800000L
-    upper.get(4) shouldBe Long.MaxValue
-    era.get(4) shouldBe -62135596800000L
+
+    start.get(4).asInstanceOf[java.time.Instant] shouldBe startOfEpoch
+    end.get(4).asInstanceOf[java.time.Instant] shouldBe endOfFormatRange
+    post.get(4).asInstanceOf[java.time.Instant] shouldBe postFormatRange
+    upper.get(4).asInstanceOf[java.time.Instant] shouldBe upperBound
+    era.get(4).asInstanceOf[java.time.Instant] shouldBe startOfEra
   }
-  
+
   test("timestamp-micros should work at the edges") {
     def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
       _timestamp_micros = time,
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfEpoch = java.time.Instant.ofEpochSecond(0, 0)
     val endOfFormatRange = java.time.Instant.ofEpochSecond(253402300799L, 999999000)
     val postFormatRange = java.time.Instant.ofEpochSecond(253402300800L, 0)
@@ -124,7 +146,7 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     postFormatRange.toString shouldBe "+10000-01-01T00:00:00Z"
     upperBound.toString shouldBe "+294247-01-10T04:00:54.775807Z"
     startOfEra.toString shouldBe "0001-01-01T00:00:00Z"
-    
+
     val start = logicalTypes(startOfEpoch)
     val end = logicalTypes(endOfFormatRange)
     val post = logicalTypes(postFormatRange)
@@ -135,26 +157,26 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.logical.LogicalTypes](serialize(post), post.getSchema) shouldBe post
     deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
     deserialize[avro2s.test.logical.LogicalTypes](serialize(era), era.getSchema) shouldBe era
-    
-    start.get(5) shouldBe 0L
-    end.get(5) shouldBe 253402300799999999L
-    post.get(5) shouldBe 253402300800000000L
-    upper.get(5) shouldBe Long.MaxValue
-    era.get(5) shouldBe -62135596800000000L
+
+    start.get(5).asInstanceOf[java.time.Instant] shouldBe startOfEpoch
+    end.get(5).asInstanceOf[java.time.Instant] shouldBe endOfFormatRange
+    post.get(5).asInstanceOf[java.time.Instant] shouldBe postFormatRange
+    upper.get(5).asInstanceOf[java.time.Instant] shouldBe upperBound
+    era.get(5).asInstanceOf[java.time.Instant] shouldBe startOfEra
   }
-  
+
   test("local-timestamp-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
       _local_timestamp_millis = time,
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC"))
     val endOfFormatRange = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(253402300799999L), java.time.ZoneId.of("UTC"))
     val postFormatRange = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(253402300800000L), java.time.ZoneId.of("UTC"))
@@ -165,7 +187,7 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     postFormatRange.toString shouldBe "+10000-01-01T00:00"
     upperBound.toString shouldBe "+292278994-08-17T07:12:55.807"
     startOfEra.toString shouldBe "0001-01-01T00:00"
-    
+
     val start = logicalTypes(startOfEpoch)
     val end = logicalTypes(endOfFormatRange)
     val post = logicalTypes(postFormatRange)
@@ -176,26 +198,26 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.logical.LogicalTypes](serialize(post), post.getSchema) shouldBe post
     deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
     deserialize[avro2s.test.logical.LogicalTypes](serialize(era), era.getSchema) shouldBe era
-    
-    start.get(6) shouldBe 0L
-    end.get(6) shouldBe 253402300799999L
-    post.get(6) shouldBe 253402300800000L
-    upper.get(6) shouldBe Long.MaxValue
-    era.get(6) shouldBe -62135596800000L
+
+    start.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEpoch
+    end.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe endOfFormatRange
+    post.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe postFormatRange
+    upper.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe upperBound
+    era.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEra
   }
-  
+
   test("local-timestamp-micros should work at the edges") {
     def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
       _local_timestamp_micros = time
     )
-    
+
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(0, 0), java.time.ZoneId.of("UTC"))
     val endOfFormatRange = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(253402300799L, 999999000), java.time.ZoneId.of("UTC"))
     val postFormatRange = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(253402300800L, 0), java.time.ZoneId.of("UTC"))
@@ -206,8 +228,8 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     postFormatRange.toString shouldBe "+10000-01-01T00:00"
     upperBound.toString shouldBe "+294247-01-10T04:00:54.775807"
     startOfEra.toString shouldBe "0001-01-01T00:00"
-    
-    
+
+
     val start = logicalTypes(startOfEpoch)
     val end = logicalTypes(endOfFormatRange)
     val post = logicalTypes(postFormatRange)
@@ -218,11 +240,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.logical.LogicalTypes](serialize(post), post.getSchema) shouldBe post
     deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
     deserialize[avro2s.test.logical.LogicalTypes](serialize(era), era.getSchema) shouldBe era
-    
-    start.get(7) shouldBe 0L
-    end.get(7) shouldBe 253402300799999999L
-    post.get(7) shouldBe 253402300800000000L
-    upper.get(7) shouldBe Long.MaxValue
-    era.get(7) shouldBe -62135596800000000L
+
+    start.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEpoch
+    end.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe endOfFormatRange
+    post.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe postFormatRange
+    upper.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe upperBound
+    era.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEra
   }
 }

--- a/avro2s/src/test/scala-2.13/avro2s/generator/logical/LogicalTypesTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/logical/LogicalTypesTest.scala
@@ -22,10 +22,10 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     java.time.Instant.ofEpochSecond(i.getEpochSecond, (i.getNano / 1000L) * 1000L)
 
   private def truncateMillisLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
-    java.time.LocalDateTime.ofInstant(truncateMillis(ldt.atZone(java.time.ZoneId.of("UTC")).toInstant), java.time.ZoneId.of("UTC"))
+    java.time.LocalDateTime.ofInstant(truncateMillis(ldt.atZone(java.time.ZoneOffset.UTC).toInstant), java.time.ZoneOffset.UTC)
 
   private def truncateMicrosLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
-    java.time.LocalDateTime.ofInstant(truncateMicros(ldt.atZone(java.time.ZoneId.of("UTC")).toInstant), java.time.ZoneId.of("UTC"))
+    java.time.LocalDateTime.ofInstant(truncateMicros(ldt.atZone(java.time.ZoneOffset.UTC).toInstant), java.time.ZoneOffset.UTC)
 
   test("time-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(

--- a/avro2s/src/test/scala-2.13/avro2s/generator/logical/LogicalTypesTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/logical/LogicalTypesTest.scala
@@ -9,34 +9,25 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   import avro2s.serialization.SerializationHelpers._
 
-  private def truncateMillis(t: java.time.LocalTime): java.time.LocalTime =
-    java.time.LocalTime.ofNanoOfDay((t.toNanoOfDay / 1000000L) * 1000000L)
-
-  private def truncateMicros(t: java.time.LocalTime): java.time.LocalTime =
-    java.time.LocalTime.ofNanoOfDay((t.toNanoOfDay / 1000L) * 1000L)
-
-  private def truncateMillis(i: java.time.Instant): java.time.Instant =
-    java.time.Instant.ofEpochMilli(i.toEpochMilli)
-
-  private def truncateMicros(i: java.time.Instant): java.time.Instant =
-    java.time.Instant.ofEpochSecond(i.getEpochSecond, (i.getNano / 1000L) * 1000L)
-
-  private def truncateMillisLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
-    java.time.LocalDateTime.ofInstant(truncateMillis(ldt.atZone(java.time.ZoneOffset.UTC).toInstant), java.time.ZoneOffset.UTC)
-
-  private def truncateMicrosLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
-    java.time.LocalDateTime.ofInstant(truncateMicros(ldt.atZone(java.time.ZoneOffset.UTC).toInstant), java.time.ZoneOffset.UTC)
+  private val fixedUuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+  private val fixedDate = java.time.LocalDate.of(2009, 2, 13)
+  private val fixedTimeMillis = java.time.LocalTime.ofNanoOfDay(45296123000000L)
+  private val fixedTimeMicros = java.time.LocalTime.ofNanoOfDay(45296123456000L)
+  private val fixedTimestampMillis = java.time.Instant.ofEpochMilli(1234567890123L)
+  private val fixedTimestampMicros = java.time.Instant.ofEpochSecond(1234567890L, 123456000L)
+  private val fixedLocalTimestampMillis = java.time.LocalDateTime.ofInstant(fixedTimestampMillis, java.time.ZoneOffset.UTC)
+  private val fixedLocalTimestampMicros = java.time.LocalDateTime.ofInstant(fixedTimestampMicros, java.time.ZoneOffset.UTC)
 
   test("time-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
+      _uuid = fixedUuid,
+      _date = fixedDate,
       _time_millis = time,
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
@@ -57,14 +48,14 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("time-micros should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
       _time_micros = time,
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
@@ -85,14 +76,14 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("timestamp-millis should work at the edges") {
     def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
       _timestamp_millis = time,
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfEpoch = java.time.Instant.ofEpochMilli(0)
@@ -126,14 +117,14 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("timestamp-micros should work at the edges") {
     def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = time,
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfEpoch = java.time.Instant.ofEpochSecond(0, 0)
@@ -167,14 +158,14 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("local-timestamp-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = time,
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC"))
@@ -208,13 +199,13 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("local-timestamp-micros should work at the edges") {
     def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
       _local_timestamp_micros = time
     )
 

--- a/avro2s/src/test/scala-2.13/avro2s/test/arrays/Arrays.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/arrays/Arrays.scala
@@ -217,7 +217,7 @@ case class Arrays(var _array_of_arrays: List[List[String]], var _array_of_maps: 
               value match {
                 case x: org.apache.avro.util.Utf8 => Coproduct[String :+: Int :+: CNil](x.toString)
                 case x: Int => Coproduct[String :+: Int :+: CNil](x)
-                case _ => throw new AvroRuntimeException("Invalid value")
+                case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
               }
             }).toList
           }
@@ -238,7 +238,7 @@ case class Arrays(var _array_of_arrays: List[List[String]], var _array_of_maps: 
                 case x: avro2s.test.arrays.Record1 => Coproduct[avro2s.test.arrays.Record1 :+: avro2s.test.arrays.Record2 :+: Int :+: CNil](x)
                 case x: avro2s.test.arrays.Record2 => Coproduct[avro2s.test.arrays.Record1 :+: avro2s.test.arrays.Record2 :+: Int :+: CNil](x)
                 case x: Int => Coproduct[avro2s.test.arrays.Record1 :+: avro2s.test.arrays.Record2 :+: Int :+: CNil](x)
-                case _ => throw new AvroRuntimeException("Invalid value")
+                case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
               }
             }).toList
           }
@@ -324,7 +324,7 @@ case class Arrays(var _array_of_arrays: List[List[String]], var _array_of_maps: 
               value match {
                 case x: avro2s.test.arrays.RecordA => Coproduct[avro2s.test.arrays.RecordA :+: avro2s.test.arrays.RecordB :+: CNil](x)
                 case x: avro2s.test.arrays.RecordB => Coproduct[avro2s.test.arrays.RecordA :+: avro2s.test.arrays.RecordB :+: CNil](x)
-                case _ => throw new AvroRuntimeException("Invalid value")
+                case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
               }
             }).toList
           }
@@ -336,7 +336,7 @@ case class Arrays(var _array_of_arrays: List[List[String]], var _array_of_maps: 
               value match {
                 case x: avro2s.test.arrays.EnumA => Coproduct[avro2s.test.arrays.EnumA :+: avro2s.test.arrays.EnumB :+: CNil](x)
                 case x: avro2s.test.arrays.EnumB => Coproduct[avro2s.test.arrays.EnumA :+: avro2s.test.arrays.EnumB :+: CNil](x)
-                case _ => throw new AvroRuntimeException("Invalid value")
+                case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
               }
             }).toList
           }
@@ -348,7 +348,7 @@ case class Arrays(var _array_of_arrays: List[List[String]], var _array_of_maps: 
               value match {
                 case x: avro2s.test.arrays.FixedA => Coproduct[avro2s.test.arrays.FixedA :+: avro2s.test.arrays.FixedB :+: CNil](x)
                 case x: avro2s.test.arrays.FixedB => Coproduct[avro2s.test.arrays.FixedA :+: avro2s.test.arrays.FixedB :+: CNil](x)
-                case _ => throw new AvroRuntimeException("Invalid value")
+                case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
               }
             }).toList
           }

--- a/avro2s/src/test/scala-2.13/avro2s/test/arrays/Arrays.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/arrays/Arrays.scala
@@ -34,7 +34,7 @@ case class Arrays(var _array_of_arrays: List[List[String]], var _array_of_maps: 
               m.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  kvp._2
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }

--- a/avro2s/src/test/scala-2.13/avro2s/test/arrays/Fixed.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/arrays/Fixed.scala
@@ -15,8 +15,8 @@ case class Fixed() extends org.apache.avro.specific.SpecificFixed {
 
 object Fixed {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"Fixed","namespace":"avro2s.test.arrays","size":2}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed](Fixed.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed](Fixed.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed](Fixed.SCHEMA$, Fixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed](Fixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): Fixed = {
     val fixed = new avro2s.test.arrays.Fixed()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-2.13/avro2s/test/arrays/FixedA.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/arrays/FixedA.scala
@@ -15,8 +15,8 @@ case class FixedA() extends org.apache.avro.specific.SpecificFixed {
 
 object FixedA {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"FixedA","namespace":"avro2s.test.arrays","size":2}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedA](FixedA.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedA](FixedA.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedA](FixedA.SCHEMA$, FixedA.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedA](FixedA.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): FixedA = {
     val fixed = new avro2s.test.arrays.FixedA()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-2.13/avro2s/test/arrays/FixedB.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/arrays/FixedB.scala
@@ -15,8 +15,8 @@ case class FixedB() extends org.apache.avro.specific.SpecificFixed {
 
 object FixedB {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"FixedB","namespace":"avro2s.test.arrays","size":2}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedB](FixedB.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedB](FixedB.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedB](FixedB.SCHEMA$, FixedB.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedB](FixedB.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): FixedB = {
     val fixed = new avro2s.test.arrays.FixedB()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypes.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypes.scala
@@ -12,6 +12,8 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
 
   override def getSchema: org.apache.avro.Schema = ComplexLogicalTypes.SCHEMA$
 
+  override def getSpecificData(): org.apache.avro.specific.SpecificData = ComplexLogicalTypes.MODEL$
+
   override def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
@@ -19,7 +21,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         _map.foreach { kvp =>
           val key = kvp._1
           val value = {
-            {kvp._2.toString}
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -30,7 +32,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         _map_alt.foreach { kvp =>
           val key = kvp._1
           val value = {
-            {kvp._2.toEpochDay.toInt}
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -40,22 +42,22 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         case array =>
           scala.jdk.CollectionConverters.BufferHasAsJava({
             array.map { x =>
-              {x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+              x.asInstanceOf[AnyRef]
             }
           }.toBuffer).asJava
         }
       case 3 => _union match {
         case Inl(x) => x.asInstanceOf[AnyRef]
-        case Inr(Inl(x)) => {x.toEpochMilli}.asInstanceOf[AnyRef]
+        case Inr(Inl(x)) => x.asInstanceOf[AnyRef]
         case _ => throw new AvroRuntimeException("Invalid value")
       }
       case 4 => _option match {
         case None => null
-        case Some(x) => {x.toString}.asInstanceOf[AnyRef]
+        case Some(x) => x.asInstanceOf[AnyRef]
       }
       case 5 => _option_alt match {
         case None => null
-        case Some(x) => {x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+        case Some(x) => x.asInstanceOf[AnyRef]
       }
       case 6 => {
         val map: java.util.HashMap[String, Any] = new java.util.HashMap[String, Any]
@@ -64,7 +66,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val value = {
             kvp._2 match {
               case Inl(x) => x.asInstanceOf[AnyRef]
-              case Inr(Inl(x)) => {x.toEpochMilli}.asInstanceOf[AnyRef]
+              case Inr(Inl(x)) => x.asInstanceOf[AnyRef]
               case _ => throw new AvroRuntimeException("Invalid value")
             }
           }
@@ -79,7 +81,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val value = {
             kvp._2 match {
               case None => null
-              case Some(x) => {x.toEpochMilli}.asInstanceOf[AnyRef]
+              case Some(x) => x.asInstanceOf[AnyRef]
             }
           }
           map.put(key, value)
@@ -93,7 +95,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val value = {
             scala.jdk.CollectionConverters.BufferHasAsJava({
               kvp._2.map { x =>
-                {x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+                x.asInstanceOf[AnyRef]
               }
             }.toBuffer).asJava
           }
@@ -108,7 +110,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              {kvp._2.toString}
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -122,7 +124,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              {kvp._2.toEpochDay.toInt}
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -133,7 +135,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         case Inl(x) => x.asInstanceOf[AnyRef]
         case Inr(Inl(x)) =>
         scala.jdk.CollectionConverters.BufferHasAsJava({
-          x.map { x =>{x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+          x.map { x =>x.asInstanceOf[AnyRef]
           }
         }.toBuffer).asJava.asInstanceOf[AnyRef]
         case _ => throw new AvroRuntimeException("Invalid value")
@@ -146,7 +148,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               m.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  {kvp._2.toString}
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }
@@ -162,7 +164,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               m.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  {kvp._2.toEpochDay.toInt}
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }
@@ -175,7 +177,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           scala.jdk.CollectionConverters.BufferHasAsJava({
             array.map {
               case Inl(x) => x.asInstanceOf[AnyRef]
-              case Inr(Inl(x)) => {x.toEpochMilli}.asInstanceOf[AnyRef]
+              case Inr(Inl(x)) => x.asInstanceOf[AnyRef]
               case _ => throw new AvroRuntimeException("Invalid value")
             }
           }.toBuffer).asJava
@@ -185,7 +187,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           scala.jdk.CollectionConverters.BufferHasAsJava({
             array.map {
               case None => null
-              case Some(x) => {x.toString}.asInstanceOf[AnyRef]
+              case Some(x) => x.asInstanceOf[AnyRef]
             }
           }.toBuffer).asJava
         }
@@ -194,7 +196,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           scala.jdk.CollectionConverters.BufferHasAsJava({
             array.map {
               case None => null
-              case Some(x) => {x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+              case Some(x) => x.asInstanceOf[AnyRef]
             }
           }.toBuffer).asJava
         }
@@ -429,4 +431,16 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
 
 object ComplexLogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"ComplexLogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_map","type":{"type":"map","values":{"type":"string","logicalType":"uuid"}}},{"name":"_map_alt","type":{"type":"map","values":{"type":"int","logicalType":"date"}}},{"name":"_array","type":{"type":"array","items":{"type":"int","logicalType":"date"}}},{"name":"_union","type":["int",{"type":"long","logicalType":"timestamp-millis"}]},{"name":"_option","type":["null",{"type":"string","logicalType":"uuid"}]},{"name":"_option_alt","type":["null",{"type":"int","logicalType":"date"}]},{"name":"_map_union","type":{"type":"map","values":["int",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_map_option","type":{"type":"map","values":["null",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_map_array","type":{"type":"map","values":{"type":"array","items":{"type":"int","logicalType":"date"}}}},{"name":"_union_map","type":["int",{"type":"map","values":{"type":"string","logicalType":"uuid"}}]},{"name":"_union_map_alt","type":["int",{"type":"map","values":{"type":"int","logicalType":"date"}}]},{"name":"_union_array","type":["int",{"type":"array","items":{"type":"int","logicalType":"date"}}]},{"name":"_array_map","type":{"type":"array","items":{"type":"map","values":{"type":"string","logicalType":"uuid"}}}},{"name":"_array_map_alt","type":{"type":"array","items":{"type":"map","values":{"type":"int","logicalType":"date"}}}},{"name":"_array_union","type":{"type":"array","items":["int",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_array_option","type":{"type":"array","items":["null",{"type":"string","logicalType":"uuid"}]}},{"name":"_array_option_alt","type":{"type":"array","items":["null",{"type":"int","logicalType":"date"}]}}]}""")
+  val MODEL$: org.apache.avro.specific.SpecificData = {
+    val model = new org.apache.avro.specific.SpecificData()
+    model.addLogicalTypeConversion(new org.apache.avro.Conversions.UUIDConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.DateConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMicrosConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMicrosConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion())
+    model
+  }
 }

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypes.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypes.scala
@@ -211,7 +211,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
+                value.asInstanceOf[java.util.UUID]
               })
             }
           }
@@ -224,7 +224,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+                value.asInstanceOf[java.time.LocalDate]
               })
             }
           }
@@ -234,7 +234,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         value match {
           case array: java.util.List[_] =>
             scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-              (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+              value.asInstanceOf[java.time.LocalDate]
             }).toList
           }
       }
@@ -242,7 +242,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         value match {
           case x: Int => Coproduct[Int :+: java.time.Instant :+: CNil](x)
           case x: java.time.Instant => Coproduct[Int :+: java.time.Instant :+: CNil](x)
-          case x: Long => Coproduct[Int :+: java.time.Instant :+: CNil]({java.time.Instant.ofEpochMilli(x)})
           case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
@@ -250,14 +249,12 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         value match {
           case null => None
           case x: java.util.UUID => Some(x)
-          case x: org.apache.avro.util.Utf8 => Some({java.util.UUID.fromString(x.toString)})
         }
       }
       case 5 => this._option_alt = {
         value match {
           case null => None
           case x: java.time.LocalDate => Some(x)
-          case x: Int => Some({java.time.LocalDate.ofEpochDay(x)})
         }
       }
       case 6 => this._map_union = {
@@ -270,7 +267,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
                 value match {
                   case x: Int => Coproduct[Int :+: java.time.Instant :+: CNil](x)
                   case x: java.time.Instant => Coproduct[Int :+: java.time.Instant :+: CNil](x)
-                  case x: Long => Coproduct[Int :+: java.time.Instant :+: CNil]({java.time.Instant.ofEpochMilli(x)})
                   case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                 }
               })
@@ -288,7 +284,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
                 value match {
                   case null => None
                   case x: java.time.Instant => Some(x)
-                  case x: Long => Some({java.time.Instant.ofEpochMilli(x)})
                 }
               })
             }
@@ -305,7 +300,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
                 value match {
                   case array: java.util.List[_] =>
                     scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-                      (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+                      value.asInstanceOf[java.time.LocalDate]
                     }).toList
                   }
               })
@@ -321,7 +316,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
+                value.asInstanceOf[java.util.UUID]
               })
             }
           }
@@ -336,7 +331,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+                value.asInstanceOf[java.time.LocalDate]
               })
             }
           }
@@ -350,7 +345,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             x match {
               case array: java.util.List[_] =>
                 scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-                  (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+                  value.asInstanceOf[java.time.LocalDate]
                 }).toList
               }
           }.toList)
@@ -367,7 +362,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
                     val key = kvp._1.toString
                     val value = kvp._2
                     (key, {
-                      (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
+                      value.asInstanceOf[java.util.UUID]
                     })
                   }
                 }
@@ -385,7 +380,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
                     val key = kvp._1.toString
                     val value = kvp._2
                     (key, {
-                      (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+                      value.asInstanceOf[java.time.LocalDate]
                     })
                   }
                 }
@@ -400,7 +395,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               value match {
                 case x: Int => Coproduct[Int :+: java.time.Instant :+: CNil](x)
                 case x: java.time.Instant => Coproduct[Int :+: java.time.Instant :+: CNil](x)
-                case x: Long => Coproduct[Int :+: java.time.Instant :+: CNil]({java.time.Instant.ofEpochMilli(x)})
                 case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
               }
             }).toList
@@ -413,7 +407,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               value match {
                 case null => None
                 case x: java.util.UUID => Some(x)
-                case x: org.apache.avro.util.Utf8 => Some({java.util.UUID.fromString(x.toString)})
               }
             }).toList
           }
@@ -425,7 +418,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               value match {
                 case null => None
                 case x: java.time.LocalDate => Some(x)
-                case x: Int => Some({java.time.LocalDate.ofEpochDay(x)})
               }
             }).toList
           }

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypes.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypes.scala
@@ -431,16 +431,14 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
 
 object ComplexLogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"ComplexLogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_map","type":{"type":"map","values":{"type":"string","logicalType":"uuid"}}},{"name":"_map_alt","type":{"type":"map","values":{"type":"int","logicalType":"date"}}},{"name":"_array","type":{"type":"array","items":{"type":"int","logicalType":"date"}}},{"name":"_union","type":["int",{"type":"long","logicalType":"timestamp-millis"}]},{"name":"_option","type":["null",{"type":"string","logicalType":"uuid"}]},{"name":"_option_alt","type":["null",{"type":"int","logicalType":"date"}]},{"name":"_map_union","type":{"type":"map","values":["int",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_map_option","type":{"type":"map","values":["null",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_map_array","type":{"type":"map","values":{"type":"array","items":{"type":"int","logicalType":"date"}}}},{"name":"_union_map","type":["int",{"type":"map","values":{"type":"string","logicalType":"uuid"}}]},{"name":"_union_map_alt","type":["int",{"type":"map","values":{"type":"int","logicalType":"date"}}]},{"name":"_union_array","type":["int",{"type":"array","items":{"type":"int","logicalType":"date"}}]},{"name":"_array_map","type":{"type":"array","items":{"type":"map","values":{"type":"string","logicalType":"uuid"}}}},{"name":"_array_map_alt","type":{"type":"array","items":{"type":"map","values":{"type":"int","logicalType":"date"}}}},{"name":"_array_union","type":{"type":"array","items":["int",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_array_option","type":{"type":"array","items":["null",{"type":"string","logicalType":"uuid"}]}},{"name":"_array_option_alt","type":{"type":"array","items":["null",{"type":"int","logicalType":"date"}]}}]}""")
+  val $UUIDConversion: org.apache.avro.Conversion[_] = new org.apache.avro.Conversions.UUIDConversion()
+  val $DateConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.DateConversion()
+  val $TimestampMillisConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
   val MODEL$: org.apache.avro.specific.SpecificData = {
     val model = new org.apache.avro.specific.SpecificData()
-    model.addLogicalTypeConversion(new org.apache.avro.Conversions.UUIDConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.DateConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMicrosConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMicrosConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion())
+    model.addLogicalTypeConversion($UUIDConversion)
+    model.addLogicalTypeConversion($DateConversion)
+    model.addLogicalTypeConversion($TimestampMillisConversion)
     model
   }
 }

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypes.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypes.scala
@@ -211,7 +211,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                {java.util.UUID.fromString(value.toString)}
+                (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
               })
             }
           }
@@ -224,7 +224,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+                (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
               })
             }
           }
@@ -234,26 +234,29 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         value match {
           case array: java.util.List[_] =>
             scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-              {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+              (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
             }).toList
           }
       }
       case 3 => this._union = {
         value match {
           case x: Int => Coproduct[Int :+: java.time.Instant :+: CNil](x)
+          case x: java.time.Instant => Coproduct[Int :+: java.time.Instant :+: CNil](x)
           case x: Long => Coproduct[Int :+: java.time.Instant :+: CNil]({java.time.Instant.ofEpochMilli(x)})
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 4 => this._option = {
         value match {
           case null => None
+          case x: java.util.UUID => Some(x)
           case x: org.apache.avro.util.Utf8 => Some({java.util.UUID.fromString(x.toString)})
         }
       }
       case 5 => this._option_alt = {
         value match {
           case null => None
+          case x: java.time.LocalDate => Some(x)
           case x: Int => Some({java.time.LocalDate.ofEpochDay(x)})
         }
       }
@@ -266,8 +269,9 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               (key, {
                 value match {
                   case x: Int => Coproduct[Int :+: java.time.Instant :+: CNil](x)
+                  case x: java.time.Instant => Coproduct[Int :+: java.time.Instant :+: CNil](x)
                   case x: Long => Coproduct[Int :+: java.time.Instant :+: CNil]({java.time.Instant.ofEpochMilli(x)})
-                  case _ => throw new AvroRuntimeException("Invalid value")
+                  case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                 }
               })
             }
@@ -283,6 +287,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               (key, {
                 value match {
                   case null => None
+                  case x: java.time.Instant => Some(x)
                   case x: Long => Some({java.time.Instant.ofEpochMilli(x)})
                 }
               })
@@ -300,7 +305,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
                 value match {
                   case array: java.util.List[_] =>
                     scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-                      {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+                      (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
                     }).toList
                   }
               })
@@ -316,11 +321,11 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                {java.util.UUID.fromString(value.toString)}
+                (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
               })
             }
           }
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 10 => this._union_map_alt = {
@@ -331,11 +336,11 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+                (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
               })
             }
           }
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 11 => this._union_array = {
@@ -345,11 +350,11 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             x match {
               case array: java.util.List[_] =>
                 scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-                  {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+                  (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
                 }).toList
               }
           }.toList)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 12 => this._array_map = {
@@ -362,7 +367,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
                     val key = kvp._1.toString
                     val value = kvp._2
                     (key, {
-                      {java.util.UUID.fromString(value.toString)}
+                      (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
                     })
                   }
                 }
@@ -380,7 +385,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
                     val key = kvp._1.toString
                     val value = kvp._2
                     (key, {
-                      {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+                      (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
                     })
                   }
                 }
@@ -394,8 +399,9 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
               value match {
                 case x: Int => Coproduct[Int :+: java.time.Instant :+: CNil](x)
+                case x: java.time.Instant => Coproduct[Int :+: java.time.Instant :+: CNil](x)
                 case x: Long => Coproduct[Int :+: java.time.Instant :+: CNil]({java.time.Instant.ofEpochMilli(x)})
-                case _ => throw new AvroRuntimeException("Invalid value")
+                case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
               }
             }).toList
           }
@@ -406,6 +412,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
               value match {
                 case null => None
+                case x: java.util.UUID => Some(x)
                 case x: org.apache.avro.util.Utf8 => Some({java.util.UUID.fromString(x.toString)})
               }
             }).toList
@@ -417,6 +424,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
               value match {
                 case null => None
+                case x: java.time.LocalDate => Some(x)
                 case x: Int => Some({java.time.LocalDate.ofEpochDay(x)})
               }
             }).toList

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypesDisabled.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypesDisabled.scala
@@ -161,7 +161,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
         value match {
           case x: Int => Coproduct[Int :+: Long :+: CNil](x)
           case x: Long => Coproduct[Int :+: Long :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 3 => this._option = {
@@ -180,7 +180,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
                 value match {
                   case x: Int => Coproduct[Int :+: Long :+: CNil](x)
                   case x: Long => Coproduct[Int :+: Long :+: CNil](x)
-                  case _ => throw new AvroRuntimeException("Invalid value")
+                  case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                 }
               })
             }
@@ -217,7 +217,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
               })
             }
           }
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 7 => this._union_array = {
@@ -231,7 +231,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
                 }).toList
               }
           }.toList)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 8 => this._array_map = {
@@ -259,7 +259,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
               value match {
                 case x: Int => Coproduct[Int :+: Long :+: CNil](x)
                 case x: Long => Coproduct[Int :+: Long :+: CNil](x)
-                case _ => throw new AvroRuntimeException("Invalid value")
+                case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
               }
             }).toList
           }

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypesDisabled.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/ComplexLogicalTypesDisabled.scala
@@ -19,7 +19,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
         _map.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -79,7 +79,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              kvp._2
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -103,7 +103,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
               m.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  kvp._2
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
@@ -9,6 +9,8 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
   override def getSchema: org.apache.avro.Schema = LogicalTypes.SCHEMA$
 
+  override def getSpecificData(): org.apache.avro.specific.SpecificData = LogicalTypes.MODEL$
+
   override def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => _uuid.asInstanceOf[AnyRef]
@@ -54,6 +56,18 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
 object LogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}""")
+  val MODEL$: org.apache.avro.specific.SpecificData = {
+    val model = new org.apache.avro.specific.SpecificData()
+    model.addLogicalTypeConversion(new org.apache.avro.Conversions.UUIDConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.DateConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMicrosConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMicrosConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion())
+    model
+  }
   val _uuid$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.Conversions.UUIDConversion()
   val _date$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.DateConversion()
   val _time_millis$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
@@ -11,29 +11,43 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
   override def get(field$: Int): AnyRef = {
     (field$: @switch) match {
-      case 0 => {_uuid.toString}.asInstanceOf[AnyRef]
-      case 1 => {_date.toEpochDay.toInt}.asInstanceOf[AnyRef]
-      case 2 => {(_time_millis.toNanoOfDay / 1000000L).toInt}.asInstanceOf[AnyRef]
-      case 3 => {_time_micros.toNanoOfDay / 1000L}.asInstanceOf[AnyRef]
-      case 4 => {_timestamp_millis.toEpochMilli}.asInstanceOf[AnyRef]
-      case 5 => {(_timestamp_micros.getEpochSecond * 1000000L) + (_timestamp_micros.getNano / 1000L)}.asInstanceOf[AnyRef]
-      case 6 => {_local_timestamp_millis.atZone(java.time.ZoneId.of("UTC")).toInstant.toEpochMilli}.asInstanceOf[AnyRef]
-      case 7 => {_local_timestamp_micros.atZone(java.time.ZoneId.of("UTC")).toInstant.getEpochSecond * 1000000L + _local_timestamp_micros.atZone(java.time.ZoneId.of("UTC")).toInstant.getNano / 1000L}.asInstanceOf[AnyRef]
+      case 0 => _uuid.asInstanceOf[AnyRef]
+      case 1 => _date.asInstanceOf[AnyRef]
+      case 2 => _time_millis.asInstanceOf[AnyRef]
+      case 3 => _time_micros.asInstanceOf[AnyRef]
+      case 4 => _timestamp_millis.asInstanceOf[AnyRef]
+      case 5 => _timestamp_micros.asInstanceOf[AnyRef]
+      case 6 => _local_timestamp_millis.asInstanceOf[AnyRef]
+      case 7 => _local_timestamp_micros.asInstanceOf[AnyRef]
       case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
     }
   }
 
   override def put(field$: Int, value: Any): Unit = {
     (field$: @switch) match {
-      case 0 => this._uuid = {java.util.UUID.fromString(value.toString.asInstanceOf[String])}
-      case 1 => this._date = {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
-      case 2 => this._time_millis = {java.time.LocalTime.ofNanoOfDay(value.asInstanceOf[Int] * 1000000L)}
-      case 3 => this._time_micros = {java.time.LocalTime.ofNanoOfDay(value.asInstanceOf[Long] * 1000L)}
-      case 4 => this._timestamp_millis = {java.time.Instant.ofEpochMilli(value.asInstanceOf[Long])}
-      case 5 => this._timestamp_micros = {java.time.Instant.ofEpochSecond(value.asInstanceOf[Long] / 1000000L, (value.asInstanceOf[Long] % 1000000L) * 1000L)}
-      case 6 => this._local_timestamp_millis = {java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(value.asInstanceOf[Long]), java.time.ZoneId.of("UTC"))}
-      case 7 => this._local_timestamp_micros = {java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(value.asInstanceOf[Long] / 1000000L, (value.asInstanceOf[Long] % 1000000L) * 1000L), java.time.ZoneId.of("UTC"))}
+      case 0 => this._uuid = value.asInstanceOf[java.util.UUID]
+      case 1 => this._date = value.asInstanceOf[java.time.LocalDate]
+      case 2 => this._time_millis = value.asInstanceOf[java.time.LocalTime]
+      case 3 => this._time_micros = value.asInstanceOf[java.time.LocalTime]
+      case 4 => this._timestamp_millis = value.asInstanceOf[java.time.Instant]
+      case 5 => this._timestamp_micros = value.asInstanceOf[java.time.Instant]
+      case 6 => this._local_timestamp_millis = value.asInstanceOf[java.time.LocalDateTime]
+      case 7 => this._local_timestamp_micros = value.asInstanceOf[java.time.LocalDateTime]
       case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def getConversion(field: Int): org.apache.avro.Conversion[_] = {
+    (field: @switch) match {
+      case 0 => new org.apache.avro.Conversions.UUIDConversion()
+      case 1 => new org.apache.avro.data.TimeConversions.DateConversion()
+      case 2 => new org.apache.avro.data.TimeConversions.TimeMillisConversion()
+      case 3 => new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
+      case 4 => new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
+      case 5 => new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
+      case 6 => new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
+      case 7 => new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
+      case _ => null
     }
   }
 }

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
@@ -41,14 +41,14 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
   override def getConversion(field: Int): org.apache.avro.Conversion[_] = {
     (field: @switch) match {
-      case 0 => LogicalTypes._uuid$Conversion
-      case 1 => LogicalTypes._date$Conversion
-      case 2 => LogicalTypes._time_millis$Conversion
-      case 3 => LogicalTypes._time_micros$Conversion
-      case 4 => LogicalTypes._timestamp_millis$Conversion
-      case 5 => LogicalTypes._timestamp_micros$Conversion
-      case 6 => LogicalTypes._local_timestamp_millis$Conversion
-      case 7 => LogicalTypes._local_timestamp_micros$Conversion
+      case 0 => LogicalTypes.$UUIDConversion
+      case 1 => LogicalTypes.$DateConversion
+      case 2 => LogicalTypes.$TimeMillisConversion
+      case 3 => LogicalTypes.$TimeMicrosConversion
+      case 4 => LogicalTypes.$TimestampMillisConversion
+      case 5 => LogicalTypes.$TimestampMicrosConversion
+      case 6 => LogicalTypes.$LocalTimestampMillisConversion
+      case 7 => LogicalTypes.$LocalTimestampMicrosConversion
       case _ => null
     }
   }
@@ -56,24 +56,24 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
 object LogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}""")
+  val $UUIDConversion: org.apache.avro.Conversion[_] = new org.apache.avro.Conversions.UUIDConversion()
+  val $DateConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.DateConversion()
+  val $TimeMillisConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()
+  val $TimeMicrosConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
+  val $TimestampMillisConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
+  val $TimestampMicrosConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
+  val $LocalTimestampMillisConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
+  val $LocalTimestampMicrosConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
   val MODEL$: org.apache.avro.specific.SpecificData = {
     val model = new org.apache.avro.specific.SpecificData()
-    model.addLogicalTypeConversion(new org.apache.avro.Conversions.UUIDConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.DateConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMicrosConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMicrosConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion())
+    model.addLogicalTypeConversion($UUIDConversion)
+    model.addLogicalTypeConversion($DateConversion)
+    model.addLogicalTypeConversion($TimeMillisConversion)
+    model.addLogicalTypeConversion($TimeMicrosConversion)
+    model.addLogicalTypeConversion($TimestampMillisConversion)
+    model.addLogicalTypeConversion($TimestampMicrosConversion)
+    model.addLogicalTypeConversion($LocalTimestampMillisConversion)
+    model.addLogicalTypeConversion($LocalTimestampMicrosConversion)
     model
   }
-  val _uuid$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.Conversions.UUIDConversion()
-  val _date$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.DateConversion()
-  val _time_millis$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()
-  val _time_micros$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
-  val _timestamp_millis$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
-  val _timestamp_micros$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
-  val _local_timestamp_millis$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
-  val _local_timestamp_micros$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
 }

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
@@ -39,14 +39,14 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
   override def getConversion(field: Int): org.apache.avro.Conversion[_] = {
     (field: @switch) match {
-      case 0 => new org.apache.avro.Conversions.UUIDConversion()
-      case 1 => new org.apache.avro.data.TimeConversions.DateConversion()
-      case 2 => new org.apache.avro.data.TimeConversions.TimeMillisConversion()
-      case 3 => new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
-      case 4 => new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
-      case 5 => new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
-      case 6 => new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
-      case 7 => new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
+      case 0 => LogicalTypes._uuid$Conversion
+      case 1 => LogicalTypes._date$Conversion
+      case 2 => LogicalTypes._time_millis$Conversion
+      case 3 => LogicalTypes._time_micros$Conversion
+      case 4 => LogicalTypes._timestamp_millis$Conversion
+      case 5 => LogicalTypes._timestamp_micros$Conversion
+      case 6 => LogicalTypes._local_timestamp_millis$Conversion
+      case 7 => LogicalTypes._local_timestamp_micros$Conversion
       case _ => null
     }
   }
@@ -54,4 +54,12 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
 object LogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}""")
+  val _uuid$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.Conversions.UUIDConversion()
+  val _date$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.DateConversion()
+  val _time_millis$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()
+  val _time_micros$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
+  val _timestamp_millis$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
+  val _timestamp_micros$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
+  val _local_timestamp_millis$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
+  val _local_timestamp_micros$Conversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
 }

--- a/avro2s/src/test/scala-2.13/avro2s/test/maps/Fixed.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/maps/Fixed.scala
@@ -15,8 +15,8 @@ case class Fixed() extends org.apache.avro.specific.SpecificFixed {
 
 object Fixed {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"Fixed","namespace":"avro2s.test.maps","size":2}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed](Fixed.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed](Fixed.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed](Fixed.SCHEMA$, Fixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed](Fixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): Fixed = {
     val fixed = new avro2s.test.maps.Fixed()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-2.13/avro2s/test/maps/Maps.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/maps/Maps.scala
@@ -23,7 +23,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
             kvp._2.foreach { kvp =>
               val key = kvp._1
               val value = {
-                kvp._2
+                kvp._2.asInstanceOf[AnyRef]
               }
               map.put(key, value)
             }
@@ -116,7 +116,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
                 m.foreach { kvp =>
                   val key = kvp._1
                   val value = {
-                    kvp._2
+                    kvp._2.asInstanceOf[AnyRef]
                   }
                   map.put(key, value)
                 }
@@ -182,7 +182,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_fixed.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -193,7 +193,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_enum.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -204,7 +204,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_record.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -242,7 +242,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_string.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -253,7 +253,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_int.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -264,7 +264,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_long.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -275,7 +275,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_float.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -286,7 +286,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_double.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -297,7 +297,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_boolean.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -308,7 +308,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_null.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }

--- a/avro2s/src/test/scala-2.13/avro2s/test/maps/Maps.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/maps/Maps.scala
@@ -373,7 +373,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
                 value match {
                   case x: org.apache.avro.util.Utf8 => Coproduct[String :+: Int :+: CNil](x.toString)
                   case x: Int => Coproduct[String :+: Int :+: CNil](x)
-                  case _ => throw new AvroRuntimeException("Invalid value")
+                  case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                 }
               })
             }
@@ -408,7 +408,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
                                   case x: Boolean => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                                   case x: Double => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                                   case x @ null => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
-                                  case _ => throw new AvroRuntimeException("Invalid value")
+                                  case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                                 }
                               })
                             }
@@ -418,7 +418,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
                     }
                   }
                   case x @ null => Coproduct[String :+: Long :+: Boolean :+: Map[String, Map[String, String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil]] :+: scala.Null :+: CNil](x)
-                  case _ => throw new AvroRuntimeException("Invalid value")
+                  case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                 }
               })
             }
@@ -490,7 +490,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
                           case x: Boolean => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                           case x: Double => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                           case x @ null => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
-                          case _ => throw new AvroRuntimeException("Invalid value")
+                          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                         }
                       })
                     }
@@ -579,7 +579,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
                   case x: avro2s.test.maps.Record => Coproduct[avro2s.test.maps.Record :+: Int :+: scala.Null :+: CNil](x)
                   case x: Int => Coproduct[avro2s.test.maps.Record :+: Int :+: scala.Null :+: CNil](x)
                   case x @ null => Coproduct[avro2s.test.maps.Record :+: Int :+: scala.Null :+: CNil](x)
-                  case _ => throw new AvroRuntimeException("Invalid value")
+                  case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                 }
               })
             }
@@ -710,7 +710,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
                   }.toList)
                   case x: Int => Coproduct[List[String] :+: Int :+: scala.Null :+: CNil](x)
                   case x @ null => Coproduct[List[String] :+: Int :+: scala.Null :+: CNil](x)
-                  case _ => throw new AvroRuntimeException("Invalid value")
+                  case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                 }
               })
             }

--- a/avro2s/src/test/scala-2.13/avro2s/test/namespaces/explicit/RecordWithExplicitNamespace.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/namespaces/explicit/RecordWithExplicitNamespace.scala
@@ -73,7 +73,7 @@ case class RecordWithExplicitNamespace(var _string: String, var _record_with_nam
         value match {
           case x: avro2s.test.namespaces.explicit.RecordWithNamespaceInheritedViaUnion => Coproduct[avro2s.test.namespaces.explicit.RecordWithNamespaceInheritedViaUnion :+: String :+: CNil](x)
           case x: org.apache.avro.util.Utf8 => Coproduct[avro2s.test.namespaces.explicit.RecordWithNamespaceInheritedViaUnion :+: String :+: CNil](x.toString)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")

--- a/avro2s/src/test/scala-2.13/avro2s/test/namespaces/explicit/RecordWithExplicitNamespace.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/namespaces/explicit/RecordWithExplicitNamespace.scala
@@ -29,7 +29,7 @@ case class RecordWithExplicitNamespace(var _string: String, var _record_with_nam
         _map_of_records.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }

--- a/avro2s/src/test/scala-2.13/avro2s/test/spec/AvroSpec.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/spec/AvroSpec.scala
@@ -36,7 +36,7 @@ case class AvroSpec(var _null: scala.Null, var _boolean: Boolean, var _int: Int,
         _map.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }

--- a/avro2s/src/test/scala-2.13/avro2s/test/spec/AvroSpec.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/spec/AvroSpec.scala
@@ -102,7 +102,7 @@ case class AvroSpec(var _null: scala.Null, var _boolean: Boolean, var _int: Int,
         value match {
           case x: org.apache.avro.util.Utf8 => Coproduct[String :+: Int :+: CNil](x.toString)
           case x: Int => Coproduct[String :+: Int :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 13 => this._fixed = value.asInstanceOf[avro2s.test.spec.md5]

--- a/avro2s/src/test/scala-2.13/avro2s/test/spec/md5.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/spec/md5.scala
@@ -15,8 +15,8 @@ case class md5() extends org.apache.avro.specific.SpecificFixed {
 
 object md5 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"md5","namespace":"avro2s.test.spec","size":16}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[md5](md5.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[md5](md5.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[md5](md5.SCHEMA$, md5.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[md5](md5.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): md5 = {
     val fixed = new avro2s.test.spec.md5()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-2.13/avro2s/test/unions/ComplexOptions.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/unions/ComplexOptions.scala
@@ -37,7 +37,7 @@ case class ComplexOptions(var _map_of_option_of_record: Map[String, Option[avro2
                 x.foreach { kvp =>
                   val key = kvp._1
                   val value = {
-                    kvp._2
+                    kvp._2.asInstanceOf[AnyRef]
                   }
                   map.put(key, value)
                 }
@@ -85,7 +85,7 @@ case class ComplexOptions(var _map_of_option_of_record: Map[String, Option[avro2
                 x.foreach { kvp =>
                   val key = kvp._1
                   val value = {
-                    kvp._2
+                    kvp._2.asInstanceOf[AnyRef]
                   }
                   map.put(key, value)
                 }

--- a/avro2s/src/test/scala-2.13/avro2s/test/unions/Fixed1.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/unions/Fixed1.scala
@@ -15,8 +15,8 @@ case class Fixed1() extends org.apache.avro.specific.SpecificFixed {
 
 object Fixed1 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"Fixed1","namespace":"avro2s.test.unions","size":1}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed1](Fixed1.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed1](Fixed1.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed1](Fixed1.SCHEMA$, Fixed1.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed1](Fixed1.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): Fixed1 = {
     val fixed = new avro2s.test.unions.Fixed1()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-2.13/avro2s/test/unions/Fixed2.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/unions/Fixed2.scala
@@ -15,8 +15,8 @@ case class Fixed2() extends org.apache.avro.specific.SpecificFixed {
 
 object Fixed2 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"Fixed2","namespace":"avro2s.test.unions","size":1}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed2](Fixed2.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed2](Fixed2.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed2](Fixed2.SCHEMA$, Fixed2.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed2](Fixed2.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): Fixed2 = {
     val fixed = new avro2s.test.unions.Fixed2()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-2.13/avro2s/test/unions/FixedForComplexOptions.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/unions/FixedForComplexOptions.scala
@@ -15,8 +15,8 @@ case class FixedForComplexOptions() extends org.apache.avro.specific.SpecificFix
 
 object FixedForComplexOptions {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"FixedForComplexOptions","namespace":"avro2s.test.unions","size":16}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedForComplexOptions](FixedForComplexOptions.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedForComplexOptions](FixedForComplexOptions.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedForComplexOptions](FixedForComplexOptions.SCHEMA$, FixedForComplexOptions.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedForComplexOptions](FixedForComplexOptions.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): FixedForComplexOptions = {
     val fixed = new avro2s.test.unions.FixedForComplexOptions()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-2.13/avro2s/test/unions/Unions.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/unions/Unions.scala
@@ -232,7 +232,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              kvp._2
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -272,7 +272,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              kvp._2
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -291,7 +291,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
               kvp._2.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  kvp._2
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }

--- a/avro2s/src/test/scala-2.13/avro2s/test/unions/Unions.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/unions/Unions.scala
@@ -375,7 +375,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
                           case x: Boolean => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                           case x: Double => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                           case x @ null => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
-                          case _ => throw new AvroRuntimeException("Invalid value")
+                          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                         }
                       })
                     }
@@ -385,7 +385,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
             }
           }
           case x @ null => Coproduct[String :+: Long :+: Boolean :+: Map[String, Map[String, String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil]] :+: scala.Null :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 1 => this._union_of_map_of_option = {
@@ -406,7 +406,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
             }
           }
           case x @ null => Coproduct[String :+: Long :+: Boolean :+: Map[String, Option[String]] :+: scala.Null :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 2 => this._union_of_array_of_option = {
@@ -426,7 +426,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
               }
           }.toList)
           case x @ null => Coproduct[String :+: Long :+: Boolean :+: List[Option[String]] :+: scala.Null :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 3 => this._union_of_array_of_union = {
@@ -445,13 +445,13 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
                     case x: Double => Coproduct[String :+: Long :+: Boolean :+: Double :+: Array[Byte] :+: scala.Null :+: CNil](x)
                     case x: java.nio.ByteBuffer => Coproduct[String :+: Long :+: Boolean :+: Double :+: Array[Byte] :+: scala.Null :+: CNil](x.array())
                     case x @ null => Coproduct[String :+: Long :+: Boolean :+: Double :+: Array[Byte] :+: scala.Null :+: CNil](x)
-                    case _ => throw new AvroRuntimeException("Invalid value")
+                    case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                   }
                 }).toList
               }
           }.toList)
           case x @ null => Coproduct[String :+: Long :+: Boolean :+: List[String :+: Long :+: Boolean :+: Double :+: Array[Byte] :+: scala.Null :+: CNil] :+: scala.Null :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 4 => this._union_of_array_of_array = {
@@ -472,7 +472,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
                           case x: Boolean => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                           case x: Double => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                           case x @ null => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
-                          case _ => throw new AvroRuntimeException("Invalid value")
+                          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                         }
                       }).toList
                     }
@@ -480,7 +480,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
               }
           }.toList)
           case x @ null => Coproduct[String :+: Long :+: Boolean :+: List[List[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil]] :+: scala.Null :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 5 => this._union_of_records = {
@@ -491,7 +491,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
           case x: avro2s.test.unions.Record1 => Coproduct[String :+: Long :+: Boolean :+: avro2s.test.unions.Record1 :+: avro2s.test.unions.Record2 :+: scala.Null :+: CNil](x)
           case x: avro2s.test.unions.Record2 => Coproduct[String :+: Long :+: Boolean :+: avro2s.test.unions.Record1 :+: avro2s.test.unions.Record2 :+: scala.Null :+: CNil](x)
           case x @ null => Coproduct[String :+: Long :+: Boolean :+: avro2s.test.unions.Record1 :+: avro2s.test.unions.Record2 :+: scala.Null :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 6 => this._union_of_enum = {
@@ -501,7 +501,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
           case x: Boolean => Coproduct[String :+: Long :+: Boolean :+: avro2s.test.unions.Enum1 :+: scala.Null :+: CNil](x)
           case x: avro2s.test.unions.Enum1 => Coproduct[String :+: Long :+: Boolean :+: avro2s.test.unions.Enum1 :+: scala.Null :+: CNil](x)
           case x @ null => Coproduct[String :+: Long :+: Boolean :+: avro2s.test.unions.Enum1 :+: scala.Null :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 7 => this._union_of_fixed = {
@@ -511,7 +511,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
           case x: Boolean => Coproduct[String :+: Long :+: Boolean :+: avro2s.test.unions.Fixed1 :+: scala.Null :+: CNil](x)
           case x: avro2s.test.unions.Fixed1 => Coproduct[String :+: Long :+: Boolean :+: avro2s.test.unions.Fixed1 :+: scala.Null :+: CNil](x)
           case x @ null => Coproduct[String :+: Long :+: Boolean :+: avro2s.test.unions.Fixed1 :+: scala.Null :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 8 => this._union_of_string = {
@@ -519,49 +519,49 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
           case x: org.apache.avro.util.Utf8 => Coproduct[String :+: Long :+: scala.Null :+: CNil](x.toString)
           case x: Long => Coproduct[String :+: Long :+: scala.Null :+: CNil](x)
           case x @ null => Coproduct[String :+: Long :+: scala.Null :+: CNil](x)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 9 => this._union_of_int = {
         value match {
           case x: Int => Coproduct[Int :+: String :+: CNil](x)
           case x: org.apache.avro.util.Utf8 => Coproduct[Int :+: String :+: CNil](x.toString)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 10 => this._union_of_long = {
         value match {
           case x: Long => Coproduct[Long :+: String :+: CNil](x)
           case x: org.apache.avro.util.Utf8 => Coproduct[Long :+: String :+: CNil](x.toString)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 11 => this._union_of_float = {
         value match {
           case x: Float => Coproduct[Float :+: String :+: CNil](x)
           case x: org.apache.avro.util.Utf8 => Coproduct[Float :+: String :+: CNil](x.toString)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 12 => this._union_of_double = {
         value match {
           case x: Double => Coproduct[Double :+: String :+: CNil](x)
           case x: org.apache.avro.util.Utf8 => Coproduct[Double :+: String :+: CNil](x.toString)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 13 => this._union_of_boolean = {
         value match {
           case x: Boolean => Coproduct[Boolean :+: String :+: CNil](x)
           case x: org.apache.avro.util.Utf8 => Coproduct[Boolean :+: String :+: CNil](x.toString)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 14 => this._union_of_bytes = {
         value match {
           case x: java.nio.ByteBuffer => Coproduct[Array[Byte] :+: String :+: CNil](x.array())
           case x: org.apache.avro.util.Utf8 => Coproduct[Array[Byte] :+: String :+: CNil](x.toString)
-          case _ => throw new AvroRuntimeException("Invalid value")
+          case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
       case 15 => this._optional_record = {
@@ -749,7 +749,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
                   case x: Boolean => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                   case x: Double => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                   case x @ null => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
-                  case _ => throw new AvroRuntimeException("Invalid value")
+                  case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                 }
               })
             }
@@ -769,7 +769,7 @@ case class Unions(var _union_of_map_of_union: String :+: Long :+: Boolean :+: Ma
                     case x: Boolean => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                     case x: Double => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
                     case x @ null => Coproduct[String :+: Long :+: Boolean :+: Double :+: scala.Null :+: CNil](x)
-                    case _ => throw new AvroRuntimeException("Invalid value")
+                    case _ => throw new AvroRuntimeException("Unexpected type: " + value.getClass.getName)
                   }
                 }).toList
               }

--- a/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
@@ -254,18 +254,15 @@ class SerializationTest extends AnyFunSuite with Matchers {
 
 
   test("logical types can be serialized and deserialized") {
-    val now = java.time.Instant.now()
-    val nowMillis = java.time.Instant.ofEpochMilli(now.toEpochMilli)
-    val nowMicros = java.time.Instant.ofEpochSecond(now.getEpochSecond, (now.getNano / 1000L) * 1000L)
     val logicalTypes = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.ofNanoOfDay((java.time.LocalTime.now().toNanoOfDay / 1000000L) * 1000000L),
-      _time_micros = java.time.LocalTime.ofNanoOfDay((java.time.LocalTime.now().toNanoOfDay / 1000L) * 1000L),
-      _timestamp_millis = nowMillis,
-      _timestamp_micros = nowMicros,
-      _local_timestamp_millis = java.time.LocalDateTime.ofInstant(nowMillis, java.time.ZoneId.of("UTC")),
-      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(nowMicros, java.time.ZoneId.of("UTC"))
+      _uuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000"),
+      _date = java.time.LocalDate.of(2009, 2, 13),
+      _time_millis = java.time.LocalTime.ofNanoOfDay(45296123000000L),
+      _time_micros = java.time.LocalTime.ofNanoOfDay(45296123456000L),
+      _timestamp_millis = java.time.Instant.ofEpochMilli(1234567890123L),
+      _timestamp_micros = java.time.Instant.ofEpochSecond(1234567890L, 123456000L),
+      _local_timestamp_millis = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(1234567890123L), java.time.ZoneOffset.UTC),
+      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(1234567890L, 123456000L), java.time.ZoneOffset.UTC)
     )
 
     deserialize[avro2s.test.logical.LogicalTypes](serialize(logicalTypes), logicalTypes.getSchema) shouldBe logicalTypes
@@ -273,39 +270,40 @@ class SerializationTest extends AnyFunSuite with Matchers {
 
   test("logical types disabled can be serialized and deserialized") {
     val logicalTypesDisabled = avro2s.test.logical.LogicalTypesDisabled(
-      _uuid = UUID.randomUUID().toString,
-      _date = java.time.LocalDate.now().toEpochDay.toInt,
-      _time_millis = java.time.LocalTime.now().toNanoOfDay.toInt / 1000000,
-      _time_micros = java.time.LocalTime.now().toNanoOfDay / 1000,
-      _timestamp_millis = java.time.Instant.now().toEpochMilli,
-      _timestamp_micros = java.time.Instant.now().toEpochMilli * 1000,
-      _local_timestamp_millis = java.time.LocalDateTime.now().toInstant(java.time.ZoneOffset.UTC).toEpochMilli,
-      _local_timestamp_micros = java.time.LocalDateTime.now().toInstant(java.time.ZoneOffset.UTC).toEpochMilli * 1000
+      _uuid = "550e8400-e29b-41d4-a716-446655440000",
+      _date = 14288,
+      _time_millis = 45296123,
+      _time_micros = 45296123456L,
+      _timestamp_millis = 1234567890123L,
+      _timestamp_micros = 1234567890123456L,
+      _local_timestamp_millis = 1234567890123L,
+      _local_timestamp_micros = 1234567890123456L
     )
 
     deserializeWithoutConversions[avro2s.test.logical.LogicalTypesDisabled](serializeWithoutConversions(logicalTypesDisabled), logicalTypesDisabled.getSchema) shouldBe logicalTypesDisabled
   }
 
   test("logical complex types can be serialized and deserialized") {
-    def truncateMillis(i: Instant): Instant = Instant.ofEpochMilli(i.toEpochMilli)
+    val ts = Instant.ofEpochMilli(1234567890123L)
+    val date = LocalDate.of(2009, 2, 13)
     val logicalComplexTypes = avro2s.test.logical.ComplexLogicalTypes(
-      _map = Map("a" -> UUID.randomUUID, "c" -> UUID.randomUUID),
-      _map_alt = Map("a" -> LocalDate.now, "c" -> LocalDate.now),
-      _array = List(LocalDate.now),
-      _union = truncateMillis(Instant.now),
-      _option = Some(UUID.randomUUID),
-      _option_alt = Some(LocalDate.now),
-      _map_union = Map("a" -> truncateMillis(Instant.now), "c" -> 1),
-      _map_option = Map("a" -> Some(truncateMillis(Instant.now)), "c" -> None),
-      _map_array = Map("a" -> List(LocalDate.now, LocalDate.now)),
-      _union_map = Map("a" -> UUID.randomUUID),
-      _union_map_alt = Map("a" -> LocalDate.now),
-      _union_array = List(LocalDate.now),
-      _array_map = List(Map("a" -> UUID.randomUUID), Map("e" -> UUID.randomUUID)),
-      _array_map_alt = List(Map("a" -> LocalDate.now), Map("e" -> LocalDate.now)),
-      _array_union = List(truncateMillis(Instant.now), 1),
-      _array_option = List(Some(UUID.randomUUID), None),
-      _array_option_alt = List(Some(LocalDate.now), None)
+      _map = Map("a" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440000"), "c" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440001")),
+      _map_alt = Map("a" -> date, "c" -> date),
+      _array = List(date),
+      _union = ts,
+      _option = Some(UUID.fromString("550e8400-e29b-41d4-a716-446655440002")),
+      _option_alt = Some(date),
+      _map_union = Map("a" -> ts, "c" -> 1),
+      _map_option = Map("a" -> Some(ts), "c" -> None),
+      _map_array = Map("a" -> List(date, date)),
+      _union_map = Map("a" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440003")),
+      _union_map_alt = Map("a" -> date),
+      _union_array = List(date),
+      _array_map = List(Map("a" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440004")), Map("e" -> UUID.fromString("550e8400-e29b-41d4-a716-446655440005"))),
+      _array_map_alt = List(Map("a" -> date), Map("e" -> date)),
+      _array_union = List(ts, 1),
+      _array_option = List(Some(UUID.fromString("550e8400-e29b-41d4-a716-446655440006")), None),
+      _array_option_alt = List(Some(date), None)
     )
 
     val serialized = serialize(logicalComplexTypes)
@@ -314,17 +312,17 @@ class SerializationTest extends AnyFunSuite with Matchers {
 
   test("logical complex types disabled can be serialized and deserialized") {
     val logicalComplexTypesDisabled = avro2s.test.logical.ComplexLogicalTypesDisabled(
-      _map = Map("a" -> UUID.randomUUID.toString, "c" -> UUID.randomUUID.toString),
-      _array = List(LocalDate.now.toEpochDay.toInt),
-      _union = Instant.now.toEpochMilli,
-      _option = Some(UUID.randomUUID.toString),
-      _map_union = Map("a" -> Instant.now.toEpochMilli, "c" -> 1L),
-      _map_array = Map("a" -> List(LocalDate.now.toEpochDay.toInt, LocalDate.now.toEpochDay.toInt)),
-      _union_map = Map("a" -> UUID.randomUUID.toString),
-      _union_array = List(LocalDate.now.toEpochDay.toInt),
-      _array_map = List(Map("a" -> UUID.randomUUID.toString), Map("e" -> UUID.randomUUID.toString)),
-      _array_union = List(Instant.now.toEpochMilli, 1L),
-      _array_option = List(Some(UUID.randomUUID.toString), None)
+      _map = Map("a" -> "550e8400-e29b-41d4-a716-446655440000", "c" -> "550e8400-e29b-41d4-a716-446655440001"),
+      _array = List(14288),
+      _union = 1234567890123L,
+      _option = Some("550e8400-e29b-41d4-a716-446655440002"),
+      _map_union = Map("a" -> 1234567890123L, "c" -> 1L),
+      _map_array = Map("a" -> List(14288, 14288)),
+      _union_map = Map("a" -> "550e8400-e29b-41d4-a716-446655440003"),
+      _union_array = List(14288),
+      _array_map = List(Map("a" -> "550e8400-e29b-41d4-a716-446655440004"), Map("e" -> "550e8400-e29b-41d4-a716-446655440005")),
+      _array_union = List(1234567890123L, 1L),
+      _array_option = List(Some("550e8400-e29b-41d4-a716-446655440006"), None)
     )
 
     val serialized = serializeWithoutConversions(logicalComplexTypesDisabled)

--- a/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
@@ -254,15 +254,18 @@ class SerializationTest extends AnyFunSuite with Matchers {
 
 
   test("logical types can be serialized and deserialized") {
+    val now = java.time.Instant.now()
+    val nowMillis = java.time.Instant.ofEpochMilli(now.toEpochMilli)
+    val nowMicros = java.time.Instant.ofEpochSecond(now.getEpochSecond, (now.getNano / 1000L) * 1000L)
     val logicalTypes = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _time_millis = java.time.LocalTime.ofNanoOfDay((java.time.LocalTime.now().toNanoOfDay / 1000000L) * 1000000L),
+      _time_micros = java.time.LocalTime.ofNanoOfDay((java.time.LocalTime.now().toNanoOfDay / 1000L) * 1000L),
+      _timestamp_millis = nowMillis,
+      _timestamp_micros = nowMicros,
+      _local_timestamp_millis = java.time.LocalDateTime.ofInstant(nowMillis, java.time.ZoneId.of("UTC")),
+      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(nowMicros, java.time.ZoneId.of("UTC"))
     )
 
     deserialize[avro2s.test.logical.LogicalTypes](serialize(logicalTypes), logicalTypes.getSchema) shouldBe logicalTypes
@@ -280,7 +283,7 @@ class SerializationTest extends AnyFunSuite with Matchers {
       _local_timestamp_micros = java.time.LocalDateTime.now().toInstant(java.time.ZoneOffset.UTC).toEpochMilli * 1000
     )
 
-    deserialize[avro2s.test.logical.LogicalTypesDisabled](serialize(logicalTypesDisabled), logicalTypesDisabled.getSchema) shouldBe logicalTypesDisabled
+    deserializeWithoutConversions[avro2s.test.logical.LogicalTypesDisabled](serializeWithoutConversions(logicalTypesDisabled), logicalTypesDisabled.getSchema) shouldBe logicalTypesDisabled
   }
 
   test("logical complex types can be serialized and deserialized") {
@@ -323,8 +326,8 @@ class SerializationTest extends AnyFunSuite with Matchers {
       _array_option = List(Some(UUID.randomUUID.toString), None)
     )
 
-    val serialized = serialize(logicalComplexTypesDisabled)
-    deserialize[avro2s.test.logical.ComplexLogicalTypesDisabled](serialized, logicalComplexTypesDisabled.getSchema) shouldBe logicalComplexTypesDisabled
+    val serialized = serializeWithoutConversions(logicalComplexTypesDisabled)
+    deserializeWithoutConversions[avro2s.test.logical.ComplexLogicalTypesDisabled](serialized, logicalComplexTypesDisabled.getSchema) shouldBe logicalComplexTypesDisabled
   }
 
   test("complex options can be serialized and deserialized") {
@@ -346,13 +349,28 @@ class SerializationTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.unions.ComplexOptions](serialized, complexOptions.getSchema) shouldBe complexOptions
   }
   
+  test("fixed types can be serialized and deserialized standalone") {
+    val data = Array[Byte](0x6f, 0x6e, 0x65, 0x00, 0x74, 0x77, 0x6f, 0x00, 0x74, 0x68, 0x72, 0x65, 0x65, 0x72, 0x65, 0x65)
+    val fixed = avro2s.test.spec.md5(data)
+
+    val out = new java.io.ByteArrayOutputStream()
+    val encoder = org.apache.avro.io.EncoderFactory.get().binaryEncoder(out, null)
+    avro2s.test.spec.md5.WRITER$.write(fixed, encoder)
+    encoder.flush()
+
+    val decoder = org.apache.avro.io.DecoderFactory.get().binaryDecoder(out.toByteArray, null)
+    val result = avro2s.test.spec.md5.READER$.read(null, decoder)
+
+    result.bytes() shouldBe data
+  }
+
   test("empty records can be serialized and deserialized") {
     val emptyRecords = avro2s.test.records.EmptyRecords(
       _string = "foo",
       _empty_record = avro2s.test.records.EmptyRecord(),
       _int = 5
     )
-    
+
     val serialized = serialize(emptyRecords)
     deserialize[avro2s.test.records.EmptyRecords](serialized, emptyRecords.getSchema) shouldBe emptyRecords
   }

--- a/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
@@ -287,22 +287,23 @@ class SerializationTest extends AnyFunSuite with Matchers {
   }
 
   test("logical complex types can be serialized and deserialized") {
+    def truncateMillis(i: Instant): Instant = Instant.ofEpochMilli(i.toEpochMilli)
     val logicalComplexTypes = avro2s.test.logical.ComplexLogicalTypes(
       _map = Map("a" -> UUID.randomUUID, "c" -> UUID.randomUUID),
       _map_alt = Map("a" -> LocalDate.now, "c" -> LocalDate.now),
       _array = List(LocalDate.now),
-      _union = Instant.now,
+      _union = truncateMillis(Instant.now),
       _option = Some(UUID.randomUUID),
       _option_alt = Some(LocalDate.now),
-      _map_union = Map("a" -> Instant.now, "c" -> 1),
-      _map_option = Map("a" -> Some(Instant.now), "c" -> None),
+      _map_union = Map("a" -> truncateMillis(Instant.now), "c" -> 1),
+      _map_option = Map("a" -> Some(truncateMillis(Instant.now)), "c" -> None),
       _map_array = Map("a" -> List(LocalDate.now, LocalDate.now)),
       _union_map = Map("a" -> UUID.randomUUID),
       _union_map_alt = Map("a" -> LocalDate.now),
       _union_array = List(LocalDate.now),
       _array_map = List(Map("a" -> UUID.randomUUID), Map("e" -> UUID.randomUUID)),
       _array_map_alt = List(Map("a" -> LocalDate.now), Map("e" -> LocalDate.now)),
-      _array_union = List(Instant.now, 1),
+      _array_union = List(truncateMillis(Instant.now), 1),
       _array_option = List(Some(UUID.randomUUID), None),
       _array_option_alt = List(Some(LocalDate.now), None)
     )

--- a/avro2s/src/test/scala-3/avro2s/generator/logical/LogicalTypesTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/logical/LogicalTypesTest.scala
@@ -9,34 +9,25 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   import avro2s.serialization.SerializationHelpers._
 
-  private def truncateMillis(t: java.time.LocalTime): java.time.LocalTime =
-    java.time.LocalTime.ofNanoOfDay((t.toNanoOfDay / 1000000L) * 1000000L)
-
-  private def truncateMicros(t: java.time.LocalTime): java.time.LocalTime =
-    java.time.LocalTime.ofNanoOfDay((t.toNanoOfDay / 1000L) * 1000L)
-
-  private def truncateMillis(i: java.time.Instant): java.time.Instant =
-    java.time.Instant.ofEpochMilli(i.toEpochMilli)
-
-  private def truncateMicros(i: java.time.Instant): java.time.Instant =
-    java.time.Instant.ofEpochSecond(i.getEpochSecond, (i.getNano / 1000L) * 1000L)
-
-  private def truncateMillisLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
-    java.time.LocalDateTime.ofInstant(truncateMillis(ldt.atZone(java.time.ZoneId.of("UTC")).toInstant), java.time.ZoneId.of("UTC"))
-
-  private def truncateMicrosLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
-    java.time.LocalDateTime.ofInstant(truncateMicros(ldt.atZone(java.time.ZoneId.of("UTC")).toInstant), java.time.ZoneId.of("UTC"))
+  private val fixedUuid = UUID.fromString("550e8400-e29b-41d4-a716-446655440000")
+  private val fixedDate = java.time.LocalDate.of(2009, 2, 13)
+  private val fixedTimeMillis = java.time.LocalTime.ofNanoOfDay(45296123000000L)
+  private val fixedTimeMicros = java.time.LocalTime.ofNanoOfDay(45296123456000L)
+  private val fixedTimestampMillis = java.time.Instant.ofEpochMilli(1234567890123L)
+  private val fixedTimestampMicros = java.time.Instant.ofEpochSecond(1234567890L, 123456000L)
+  private val fixedLocalTimestampMillis = java.time.LocalDateTime.ofInstant(fixedTimestampMillis, java.time.ZoneOffset.UTC)
+  private val fixedLocalTimestampMicros = java.time.LocalDateTime.ofInstant(fixedTimestampMicros, java.time.ZoneOffset.UTC)
 
   test("time-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
+      _uuid = fixedUuid,
+      _date = fixedDate,
       _time_millis = time,
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
@@ -57,14 +48,14 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("time-micros should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
       _time_micros = time,
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
@@ -85,14 +76,14 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("timestamp-millis should work at the edges") {
     def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
       _timestamp_millis = time,
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfEpoch = java.time.Instant.ofEpochMilli(0)
@@ -126,14 +117,14 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("timestamp-micros should work at the edges") {
     def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = time,
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfEpoch = java.time.Instant.ofEpochSecond(0, 0)
@@ -167,14 +158,14 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("local-timestamp-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = time,
-      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
+      _local_timestamp_micros = fixedLocalTimestampMicros
     )
 
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC"))
@@ -208,13 +199,13 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   test("local-timestamp-micros should work at the edges") {
     def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
-      _uuid = UUID.randomUUID(),
-      _date = java.time.LocalDate.now(),
-      _time_millis = truncateMillis(java.time.LocalTime.now()),
-      _time_micros = truncateMicros(java.time.LocalTime.now()),
-      _timestamp_millis = truncateMillis(java.time.Instant.now()),
-      _timestamp_micros = truncateMicros(java.time.Instant.now()),
-      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
       _local_timestamp_micros = time
     )
 

--- a/avro2s/src/test/scala-3/avro2s/generator/logical/LogicalTypesTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/logical/LogicalTypesTest.scala
@@ -8,71 +8,93 @@ import java.util.UUID
 class LogicalTypesTest extends AnyFunSuite with Matchers {
 
   import avro2s.serialization.SerializationHelpers._
-  
+
+  private def truncateMillis(t: java.time.LocalTime): java.time.LocalTime =
+    java.time.LocalTime.ofNanoOfDay((t.toNanoOfDay / 1000000L) * 1000000L)
+
+  private def truncateMicros(t: java.time.LocalTime): java.time.LocalTime =
+    java.time.LocalTime.ofNanoOfDay((t.toNanoOfDay / 1000L) * 1000L)
+
+  private def truncateMillis(i: java.time.Instant): java.time.Instant =
+    java.time.Instant.ofEpochMilli(i.toEpochMilli)
+
+  private def truncateMicros(i: java.time.Instant): java.time.Instant =
+    java.time.Instant.ofEpochSecond(i.getEpochSecond, (i.getNano / 1000L) * 1000L)
+
+  private def truncateMillisLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
+    java.time.LocalDateTime.ofInstant(truncateMillis(ldt.atZone(java.time.ZoneId.of("UTC")).toInstant), java.time.ZoneId.of("UTC"))
+
+  private def truncateMicrosLdt(ldt: java.time.LocalDateTime): java.time.LocalDateTime =
+    java.time.LocalDateTime.ofInstant(truncateMicros(ldt.atZone(java.time.ZoneId.of("UTC")).toInstant), java.time.ZoneId.of("UTC"))
+
   test("time-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
       _time_millis = time,
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
     val endOfDay = java.time.LocalTime.ofNanoOfDay(86399999999999L)
     startOfDay.format(java.time.format.DateTimeFormatter.ISO_LOCAL_TIME) shouldBe "00:00:00"
     endOfDay.format(java.time.format.DateTimeFormatter.ISO_LOCAL_TIME) shouldBe "23:59:59.999999999"
-    
+
     val start = logicalTypes(startOfDay)
     val end = logicalTypes(endOfDay)
     deserialize[avro2s.test.logical.LogicalTypes](serialize(start), start.getSchema) shouldBe start
-    deserialize[avro2s.test.logical.LogicalTypes](serialize(end), end.getSchema) shouldBe end
-    
-    start.get(2).asInstanceOf[Int] shouldBe 0
-    end.get(2).asInstanceOf[Int] shouldBe 86399999
+    // endOfDay has nanosecond precision that gets truncated to millis
+    val endDeserialized = deserialize[avro2s.test.logical.LogicalTypes](serialize(end), end.getSchema)
+    endDeserialized._time_millis shouldBe java.time.LocalTime.ofNanoOfDay(86399999000000L)
+
+    start.get(2).asInstanceOf[java.time.LocalTime] shouldBe startOfDay
+    end.get(2).asInstanceOf[java.time.LocalTime] shouldBe endOfDay
   }
-  
+
   test("time-micros should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
       _time_micros = time,
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
     val endOfDay = java.time.LocalTime.ofNanoOfDay(86399999999999L)
     startOfDay.format(java.time.format.DateTimeFormatter.ISO_LOCAL_TIME) shouldBe "00:00:00"
     endOfDay.format(java.time.format.DateTimeFormatter.ISO_LOCAL_TIME) shouldBe "23:59:59.999999999"
-    
+
     val start = logicalTypes(startOfDay)
     val end = logicalTypes(endOfDay)
     deserialize[avro2s.test.logical.LogicalTypes](serialize(start), start.getSchema) shouldBe start
-    deserialize[avro2s.test.logical.LogicalTypes](serialize(end), end.getSchema) shouldBe end
-    
-    start.get(3).asInstanceOf[Long] shouldBe 0L
-    end.get(3).asInstanceOf[Long] shouldBe 86399999999L
+    // endOfDay has nanosecond precision that gets truncated to micros
+    val endDeserialized = deserialize[avro2s.test.logical.LogicalTypes](serialize(end), end.getSchema)
+    endDeserialized._time_micros shouldBe java.time.LocalTime.ofNanoOfDay(86399999999000L)
+
+    start.get(3).asInstanceOf[java.time.LocalTime] shouldBe startOfDay
+    end.get(3).asInstanceOf[java.time.LocalTime] shouldBe endOfDay
   }
-  
+
   test("timestamp-millis should work at the edges") {
     def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
       _timestamp_millis = time,
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfEpoch = java.time.Instant.ofEpochMilli(0)
     val endOfFormatRange = java.time.Instant.ofEpochMilli(253402300799999L)
     val postFormatRange = java.time.Instant.ofEpochMilli(253402300800000L)
@@ -83,7 +105,7 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     postFormatRange.toString shouldBe "+10000-01-01T00:00:00Z"
     upperBound.toString shouldBe "+292278994-08-17T07:12:55.807Z"
     startOfEra.toString shouldBe "0001-01-01T00:00:00Z"
-    
+
     val start = logicalTypes(startOfEpoch)
     val end = logicalTypes(endOfFormatRange)
     val post = logicalTypes(postFormatRange)
@@ -94,26 +116,26 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.logical.LogicalTypes](serialize(post), post.getSchema) shouldBe post
     deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
     deserialize[avro2s.test.logical.LogicalTypes](serialize(era), era.getSchema) shouldBe era
-    
-    start.get(4).asInstanceOf[Long] shouldBe 0L
-    end.get(4).asInstanceOf[Long] shouldBe 253402300799999L
-    post.get(4).asInstanceOf[Long] shouldBe 253402300800000L
-    upper.get(4).asInstanceOf[Long] shouldBe Long.MaxValue
-    era.get(4).asInstanceOf[Long] shouldBe -62135596800000L
+
+    start.get(4).asInstanceOf[java.time.Instant] shouldBe startOfEpoch
+    end.get(4).asInstanceOf[java.time.Instant] shouldBe endOfFormatRange
+    post.get(4).asInstanceOf[java.time.Instant] shouldBe postFormatRange
+    upper.get(4).asInstanceOf[java.time.Instant] shouldBe upperBound
+    era.get(4).asInstanceOf[java.time.Instant] shouldBe startOfEra
   }
-  
+
   test("timestamp-micros should work at the edges") {
     def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
       _timestamp_micros = time,
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfEpoch = java.time.Instant.ofEpochSecond(0, 0)
     val endOfFormatRange = java.time.Instant.ofEpochSecond(253402300799L, 999999000)
     val postFormatRange = java.time.Instant.ofEpochSecond(253402300800L, 0)
@@ -124,7 +146,7 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     postFormatRange.toString shouldBe "+10000-01-01T00:00:00Z"
     upperBound.toString shouldBe "+294247-01-10T04:00:54.775807Z"
     startOfEra.toString shouldBe "0001-01-01T00:00:00Z"
-    
+
     val start = logicalTypes(startOfEpoch)
     val end = logicalTypes(endOfFormatRange)
     val post = logicalTypes(postFormatRange)
@@ -135,26 +157,26 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.logical.LogicalTypes](serialize(post), post.getSchema) shouldBe post
     deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
     deserialize[avro2s.test.logical.LogicalTypes](serialize(era), era.getSchema) shouldBe era
-    
-    start.get(5).asInstanceOf[Long] shouldBe 0L
-    end.get(5).asInstanceOf[Long] shouldBe 253402300799999999L
-    post.get(5).asInstanceOf[Long] shouldBe 253402300800000000L
-    upper.get(5).asInstanceOf[Long] shouldBe Long.MaxValue
-    era.get(5).asInstanceOf[Long] shouldBe -62135596800000000L
+
+    start.get(5).asInstanceOf[java.time.Instant] shouldBe startOfEpoch
+    end.get(5).asInstanceOf[java.time.Instant] shouldBe endOfFormatRange
+    post.get(5).asInstanceOf[java.time.Instant] shouldBe postFormatRange
+    upper.get(5).asInstanceOf[java.time.Instant] shouldBe upperBound
+    era.get(5).asInstanceOf[java.time.Instant] shouldBe startOfEra
   }
-  
+
   test("local-timestamp-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
       _local_timestamp_millis = time,
-      _local_timestamp_micros = java.time.LocalDateTime.now()
+      _local_timestamp_micros = truncateMicrosLdt(java.time.LocalDateTime.now())
     )
-    
+
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC"))
     val endOfFormatRange = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(253402300799999L), java.time.ZoneId.of("UTC"))
     val postFormatRange = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(253402300800000L), java.time.ZoneId.of("UTC"))
@@ -165,7 +187,7 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     postFormatRange.toString shouldBe "+10000-01-01T00:00"
     upperBound.toString shouldBe "+292278994-08-17T07:12:55.807"
     startOfEra.toString shouldBe "0001-01-01T00:00"
-    
+
     val start = logicalTypes(startOfEpoch)
     val end = logicalTypes(endOfFormatRange)
     val post = logicalTypes(postFormatRange)
@@ -176,26 +198,26 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.logical.LogicalTypes](serialize(post), post.getSchema) shouldBe post
     deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
     deserialize[avro2s.test.logical.LogicalTypes](serialize(era), era.getSchema) shouldBe era
-    
-    start.get(6).asInstanceOf[Long] shouldBe 0L
-    end.get(6).asInstanceOf[Long] shouldBe 253402300799999L
-    post.get(6).asInstanceOf[Long] shouldBe 253402300800000L
-    upper.get(6).asInstanceOf[Long] shouldBe Long.MaxValue
-    era.get(6).asInstanceOf[Long] shouldBe -62135596800000L
+
+    start.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEpoch
+    end.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe endOfFormatRange
+    post.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe postFormatRange
+    upper.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe upperBound
+    era.get(6).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEra
   }
-  
+
   test("local-timestamp-micros should work at the edges") {
     def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
       _uuid = UUID.randomUUID(),
       _date = java.time.LocalDate.now(),
-      _time_millis = java.time.LocalTime.now(),
-      _time_micros = java.time.LocalTime.now(),
-      _timestamp_millis = java.time.Instant.now(),
-      _timestamp_micros = java.time.Instant.now(),
-      _local_timestamp_millis = java.time.LocalDateTime.now(),
+      _time_millis = truncateMillis(java.time.LocalTime.now()),
+      _time_micros = truncateMicros(java.time.LocalTime.now()),
+      _timestamp_millis = truncateMillis(java.time.Instant.now()),
+      _timestamp_micros = truncateMicros(java.time.Instant.now()),
+      _local_timestamp_millis = truncateMillisLdt(java.time.LocalDateTime.now()),
       _local_timestamp_micros = time
     )
-    
+
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(0, 0), java.time.ZoneId.of("UTC"))
     val endOfFormatRange = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(253402300799L, 999999000), java.time.ZoneId.of("UTC"))
     val postFormatRange = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(253402300800L, 0), java.time.ZoneId.of("UTC"))
@@ -206,8 +228,8 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     postFormatRange.toString shouldBe "+10000-01-01T00:00"
     upperBound.toString shouldBe "+294247-01-10T04:00:54.775807"
     startOfEra.toString shouldBe "0001-01-01T00:00"
-    
-    
+
+
     val start = logicalTypes(startOfEpoch)
     val end = logicalTypes(endOfFormatRange)
     val post = logicalTypes(postFormatRange)
@@ -218,11 +240,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     deserialize[avro2s.test.logical.LogicalTypes](serialize(post), post.getSchema) shouldBe post
     deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
     deserialize[avro2s.test.logical.LogicalTypes](serialize(era), era.getSchema) shouldBe era
-    
-    start.get(7).asInstanceOf[Long] shouldBe 0L
-    end.get(7).asInstanceOf[Long] shouldBe 253402300799999999L
-    post.get(7).asInstanceOf[Long] shouldBe 253402300800000000L
-    upper.get(7).asInstanceOf[Long] shouldBe Long.MaxValue
-    era.get(7).asInstanceOf[Long] shouldBe -62135596800000000L
+
+    start.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEpoch
+    end.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe endOfFormatRange
+    post.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe postFormatRange
+    upper.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe upperBound
+    era.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEra
   }
 }

--- a/avro2s/src/test/scala-3/avro2s/test/arrays/Arrays.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/arrays/Arrays.scala
@@ -31,7 +31,7 @@ case class Arrays(var _array_of_arrays: List[List[String]], var _array_of_maps: 
               m.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  kvp._2
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }

--- a/avro2s/src/test/scala-3/avro2s/test/arrays/Fixed.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/arrays/Fixed.scala
@@ -15,8 +15,8 @@ case class Fixed() extends org.apache.avro.specific.SpecificFixed {
 
 object Fixed {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"Fixed","namespace":"avro2s.test.arrays","size":2}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed](Fixed.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed](Fixed.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed](Fixed.SCHEMA$, Fixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed](Fixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): Fixed = {
     val fixed = new avro2s.test.arrays.Fixed()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-3/avro2s/test/arrays/FixedA.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/arrays/FixedA.scala
@@ -15,8 +15,8 @@ case class FixedA() extends org.apache.avro.specific.SpecificFixed {
 
 object FixedA {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"FixedA","namespace":"avro2s.test.arrays","size":2}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedA](FixedA.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedA](FixedA.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedA](FixedA.SCHEMA$, FixedA.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedA](FixedA.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): FixedA = {
     val fixed = new avro2s.test.arrays.FixedA()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-3/avro2s/test/arrays/FixedB.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/arrays/FixedB.scala
@@ -15,8 +15,8 @@ case class FixedB() extends org.apache.avro.specific.SpecificFixed {
 
 object FixedB {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"FixedB","namespace":"avro2s.test.arrays","size":2}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedB](FixedB.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedB](FixedB.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedB](FixedB.SCHEMA$, FixedB.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedB](FixedB.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): FixedB = {
     val fixed = new avro2s.test.arrays.FixedB()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypes.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypes.scala
@@ -9,6 +9,8 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
 
   override def getSchema: org.apache.avro.Schema = ComplexLogicalTypes.SCHEMA$
 
+  override def getSpecificData(): org.apache.avro.specific.SpecificData = ComplexLogicalTypes.MODEL$
+
   override def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => {
@@ -16,7 +18,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         _map.foreach { kvp =>
           val key = kvp._1
           val value = {
-            {kvp._2.toString}
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -27,7 +29,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         _map_alt.foreach { kvp =>
           val key = kvp._1
           val value = {
-            {kvp._2.toEpochDay.toInt}
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -37,20 +39,20 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         case array =>
           scala.jdk.CollectionConverters.BufferHasAsJava({
             array.map { x =>
-              {x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+              x.asInstanceOf[AnyRef]
             }
           }.toBuffer).asJava
         }
       case 3 => _union match {
         case x: Int => x.asInstanceOf[AnyRef]
-        case x: java.time.Instant => {x.toEpochMilli}.asInstanceOf[AnyRef]
+        case x: java.time.Instant => x.asInstanceOf[AnyRef]
       }
       case 4 => _option match {
-        case Some(x: java.util.UUID) => {x.toString}.asInstanceOf[AnyRef]
+        case Some(x: java.util.UUID) => x.asInstanceOf[AnyRef]
         case None => null.asInstanceOf[AnyRef]
       }
       case 5 => _option_alt match {
-        case Some(x: java.time.LocalDate) => {x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+        case Some(x: java.time.LocalDate) => x.asInstanceOf[AnyRef]
         case None => null.asInstanceOf[AnyRef]
       }
       case 6 => {
@@ -60,7 +62,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val value = {
             kvp._2 match {
               case x: Int => x.asInstanceOf[AnyRef]
-              case x: java.time.Instant => {x.toEpochMilli}.asInstanceOf[AnyRef]
+              case x: java.time.Instant => x.asInstanceOf[AnyRef]
             }
           }
           map.put(key, value)
@@ -73,7 +75,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val key = kvp._1
           val value = {
             kvp._2 match {
-              case Some(x: java.time.Instant) => {x.toEpochMilli}.asInstanceOf[AnyRef]
+              case Some(x: java.time.Instant) => x.asInstanceOf[AnyRef]
               case None => null.asInstanceOf[AnyRef]
             }
           }
@@ -88,7 +90,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val value = {
             scala.jdk.CollectionConverters.BufferHasAsJava({
               kvp._2.map { x =>
-                {x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+                x.asInstanceOf[AnyRef]
               }
             }.toBuffer).asJava
           }
@@ -103,7 +105,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              {kvp._2.toString}
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -116,7 +118,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              {kvp._2.toEpochDay.toInt}
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -126,7 +128,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         case x: Int => x.asInstanceOf[AnyRef]
         case x: List[java.time.LocalDate] =>
         scala.jdk.CollectionConverters.BufferHasAsJava({
-          x.map { x =>{x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+          x.map { x =>x.asInstanceOf[AnyRef]
           }
         }.toBuffer).asJava.asInstanceOf[AnyRef]
       }
@@ -138,7 +140,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               m.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  {kvp._2.toString}
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }
@@ -154,7 +156,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               m.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  {kvp._2.toEpochDay.toInt}
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }
@@ -167,7 +169,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           scala.jdk.CollectionConverters.BufferHasAsJava({
             array.map {
               case x: Int => x.asInstanceOf[AnyRef]
-              case x: java.time.Instant => {x.toEpochMilli}.asInstanceOf[AnyRef]
+              case x: java.time.Instant => x.asInstanceOf[AnyRef]
             }
           }.toBuffer).asJava
         }
@@ -175,7 +177,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         case array =>
           scala.jdk.CollectionConverters.BufferHasAsJava({
             array.map {
-              case Some(x: java.util.UUID) => {x.toString}.asInstanceOf[AnyRef]
+              case Some(x: java.util.UUID) => x.asInstanceOf[AnyRef]
               case None => null.asInstanceOf[AnyRef]
             }
           }.toBuffer).asJava
@@ -184,7 +186,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         case array =>
           scala.jdk.CollectionConverters.BufferHasAsJava({
             array.map {
-              case Some(x: java.time.LocalDate) => {x.toEpochDay.toInt}.asInstanceOf[AnyRef]
+              case Some(x: java.time.LocalDate) => x.asInstanceOf[AnyRef]
               case None => null.asInstanceOf[AnyRef]
             }
           }.toBuffer).asJava
@@ -384,4 +386,16 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
 
 object ComplexLogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"ComplexLogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_map","type":{"type":"map","values":{"type":"string","logicalType":"uuid"}}},{"name":"_map_alt","type":{"type":"map","values":{"type":"int","logicalType":"date"}}},{"name":"_array","type":{"type":"array","items":{"type":"int","logicalType":"date"}}},{"name":"_union","type":["int",{"type":"long","logicalType":"timestamp-millis"}]},{"name":"_option","type":["null",{"type":"string","logicalType":"uuid"}]},{"name":"_option_alt","type":["null",{"type":"int","logicalType":"date"}]},{"name":"_map_union","type":{"type":"map","values":["int",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_map_option","type":{"type":"map","values":["null",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_map_array","type":{"type":"map","values":{"type":"array","items":{"type":"int","logicalType":"date"}}}},{"name":"_union_map","type":["int",{"type":"map","values":{"type":"string","logicalType":"uuid"}}]},{"name":"_union_map_alt","type":["int",{"type":"map","values":{"type":"int","logicalType":"date"}}]},{"name":"_union_array","type":["int",{"type":"array","items":{"type":"int","logicalType":"date"}}]},{"name":"_array_map","type":{"type":"array","items":{"type":"map","values":{"type":"string","logicalType":"uuid"}}}},{"name":"_array_map_alt","type":{"type":"array","items":{"type":"map","values":{"type":"int","logicalType":"date"}}}},{"name":"_array_union","type":{"type":"array","items":["int",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_array_option","type":{"type":"array","items":["null",{"type":"string","logicalType":"uuid"}]}},{"name":"_array_option_alt","type":{"type":"array","items":["null",{"type":"int","logicalType":"date"}]}}]}""")
+  val MODEL$: org.apache.avro.specific.SpecificData = {
+    val model = new org.apache.avro.specific.SpecificData()
+    model.addLogicalTypeConversion(new org.apache.avro.Conversions.UUIDConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.DateConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMicrosConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMicrosConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion())
+    model
+  }
 }

--- a/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypes.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypes.scala
@@ -201,7 +201,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val key = kvp._1.toString
           val value = kvp._2
           (key, {
-            {java.util.UUID.fromString(value.toString)}
+            (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
           })
         }
       }
@@ -211,19 +211,20 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val key = kvp._1.toString
           val value = kvp._2
           (key, {
-            {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+            (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
           })
         }
       }
       case 2 => this._array = {
         val array = value.asInstanceOf[java.util.List[?]]
         scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-          {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+          (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
         }).toList
       }
       case 3 => this._union = {
         value match {
           case x: Int => x
+          case x: java.time.Instant => x
           case x: Long => {java.time.Instant.ofEpochMilli(x)}
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
@@ -231,6 +232,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
       case 4 => this._option = {
         value match {
           case null => None
+          case x: java.util.UUID => Option(x)
           case x: org.apache.avro.util.Utf8 => Option({java.util.UUID.fromString(x.toString)})
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
@@ -238,6 +240,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
       case 5 => this._option_alt = {
         value match {
           case null => None
+          case x: java.time.LocalDate => Option(x)
           case x: Int => Option({java.time.LocalDate.ofEpochDay(x)})
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
@@ -250,6 +253,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           (key, {
             value match {
               case x: Int => x
+              case x: java.time.Instant => x
               case x: Long => {java.time.Instant.ofEpochMilli(x)}
               case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
             }
@@ -264,6 +268,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           (key, {
             value match {
               case null => None
+              case x: java.time.Instant => Option(x)
               case x: Long => Option({java.time.Instant.ofEpochMilli(x)})
               case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
             }
@@ -278,7 +283,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           (key, {
             val array = value.asInstanceOf[java.util.List[?]]
             scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-              {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+              (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
             }).toList
           })
         }
@@ -291,7 +296,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                {java.util.UUID.fromString(value.toString)}
+                (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
               })
             }
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
@@ -305,7 +310,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+                (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
               })
             }
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
@@ -316,7 +321,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           case x: Int => x
           case array: java.util.List[?] =>
             scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-              {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+              (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
             }).toList
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
@@ -329,7 +334,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             val key = kvp._1.toString
             val value = kvp._2
             (key, {
-              {java.util.UUID.fromString(value.toString)}
+              (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
             })
           }
         }).toList
@@ -342,7 +347,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             val key = kvp._1.toString
             val value = kvp._2
             (key, {
-              {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+              (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
             })
           }
         }).toList
@@ -352,6 +357,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
           value match {
             case x: Int => x
+            case x: java.time.Instant => x
             case x: Long => {java.time.Instant.ofEpochMilli(x)}
             case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
           }
@@ -362,6 +368,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
           value match {
             case null => None
+            case x: java.util.UUID => Option(x)
             case x: org.apache.avro.util.Utf8 => Option({java.util.UUID.fromString(x.toString)})
             case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
           }
@@ -372,6 +379,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
           value match {
             case null => None
+            case x: java.time.LocalDate => Option(x)
             case x: Int => Option({java.time.LocalDate.ofEpochDay(x)})
             case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
           }

--- a/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypes.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypes.scala
@@ -201,7 +201,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val key = kvp._1.toString
           val value = kvp._2
           (key, {
-            (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
+            value.asInstanceOf[java.util.UUID]
           })
         }
       }
@@ -211,21 +211,20 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           val key = kvp._1.toString
           val value = kvp._2
           (key, {
-            (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+            value.asInstanceOf[java.time.LocalDate]
           })
         }
       }
       case 2 => this._array = {
         val array = value.asInstanceOf[java.util.List[?]]
         scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-          (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+          value.asInstanceOf[java.time.LocalDate]
         }).toList
       }
       case 3 => this._union = {
         value match {
           case x: Int => x
           case x: java.time.Instant => x
-          case x: Long => {java.time.Instant.ofEpochMilli(x)}
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
@@ -233,7 +232,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         value match {
           case null => None
           case x: java.util.UUID => Option(x)
-          case x: org.apache.avro.util.Utf8 => Option({java.util.UUID.fromString(x.toString)})
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
@@ -241,7 +239,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
         value match {
           case null => None
           case x: java.time.LocalDate => Option(x)
-          case x: Int => Option({java.time.LocalDate.ofEpochDay(x)})
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
       }
@@ -254,7 +251,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             value match {
               case x: Int => x
               case x: java.time.Instant => x
-              case x: Long => {java.time.Instant.ofEpochMilli(x)}
               case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
             }
           })
@@ -269,7 +265,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             value match {
               case null => None
               case x: java.time.Instant => Option(x)
-              case x: Long => Option({java.time.Instant.ofEpochMilli(x)})
               case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
             }
           })
@@ -283,7 +278,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           (key, {
             val array = value.asInstanceOf[java.util.List[?]]
             scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-              (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+              value.asInstanceOf[java.time.LocalDate]
             }).toList
           })
         }
@@ -296,7 +291,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
+                value.asInstanceOf[java.util.UUID]
               })
             }
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
@@ -310,7 +305,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
               val key = kvp._1.toString
               val value = kvp._2
               (key, {
-                (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+                value.asInstanceOf[java.time.LocalDate]
               })
             }
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
@@ -321,7 +316,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           case x: Int => x
           case array: java.util.List[?] =>
             scala.jdk.CollectionConverters.IteratorHasAsScala(array.iterator).asScala.map({ value =>
-              (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+              value.asInstanceOf[java.time.LocalDate]
             }).toList
           case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
         }
@@ -334,7 +329,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             val key = kvp._1.toString
             val value = kvp._2
             (key, {
-              (value match { case x: java.util.UUID => x; case x => java.util.UUID.fromString(x.toString) })
+              value.asInstanceOf[java.util.UUID]
             })
           }
         }).toList
@@ -347,7 +342,7 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
             val key = kvp._1.toString
             val value = kvp._2
             (key, {
-              (value match { case x: java.time.LocalDate => x; case x => java.time.LocalDate.ofEpochDay(x.asInstanceOf[Int]) })
+              value.asInstanceOf[java.time.LocalDate]
             })
           }
         }).toList
@@ -358,7 +353,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           value match {
             case x: Int => x
             case x: java.time.Instant => x
-            case x: Long => {java.time.Instant.ofEpochMilli(x)}
             case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
           }
         }).toList
@@ -369,7 +363,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           value match {
             case null => None
             case x: java.util.UUID => Option(x)
-            case x: org.apache.avro.util.Utf8 => Option({java.util.UUID.fromString(x.toString)})
             case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
           }
         }).toList
@@ -380,7 +373,6 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
           value match {
             case null => None
             case x: java.time.LocalDate => Option(x)
-            case x: Int => Option({java.time.LocalDate.ofEpochDay(x)})
             case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
           }
         }).toList

--- a/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypes.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypes.scala
@@ -386,16 +386,14 @@ case class ComplexLogicalTypes(var _map: Map[String, java.util.UUID], var _map_a
 
 object ComplexLogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"ComplexLogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_map","type":{"type":"map","values":{"type":"string","logicalType":"uuid"}}},{"name":"_map_alt","type":{"type":"map","values":{"type":"int","logicalType":"date"}}},{"name":"_array","type":{"type":"array","items":{"type":"int","logicalType":"date"}}},{"name":"_union","type":["int",{"type":"long","logicalType":"timestamp-millis"}]},{"name":"_option","type":["null",{"type":"string","logicalType":"uuid"}]},{"name":"_option_alt","type":["null",{"type":"int","logicalType":"date"}]},{"name":"_map_union","type":{"type":"map","values":["int",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_map_option","type":{"type":"map","values":["null",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_map_array","type":{"type":"map","values":{"type":"array","items":{"type":"int","logicalType":"date"}}}},{"name":"_union_map","type":["int",{"type":"map","values":{"type":"string","logicalType":"uuid"}}]},{"name":"_union_map_alt","type":["int",{"type":"map","values":{"type":"int","logicalType":"date"}}]},{"name":"_union_array","type":["int",{"type":"array","items":{"type":"int","logicalType":"date"}}]},{"name":"_array_map","type":{"type":"array","items":{"type":"map","values":{"type":"string","logicalType":"uuid"}}}},{"name":"_array_map_alt","type":{"type":"array","items":{"type":"map","values":{"type":"int","logicalType":"date"}}}},{"name":"_array_union","type":{"type":"array","items":["int",{"type":"long","logicalType":"timestamp-millis"}]}},{"name":"_array_option","type":{"type":"array","items":["null",{"type":"string","logicalType":"uuid"}]}},{"name":"_array_option_alt","type":{"type":"array","items":["null",{"type":"int","logicalType":"date"}]}}]}""")
+  val $UUIDConversion: org.apache.avro.Conversion[?] = new org.apache.avro.Conversions.UUIDConversion()
+  val $DateConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.DateConversion()
+  val $TimestampMillisConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
   val MODEL$: org.apache.avro.specific.SpecificData = {
     val model = new org.apache.avro.specific.SpecificData()
-    model.addLogicalTypeConversion(new org.apache.avro.Conversions.UUIDConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.DateConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMicrosConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMicrosConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion())
+    model.addLogicalTypeConversion($UUIDConversion)
+    model.addLogicalTypeConversion($DateConversion)
+    model.addLogicalTypeConversion($TimestampMillisConversion)
     model
   }
 }

--- a/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypesDisabled.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/ComplexLogicalTypesDisabled.scala
@@ -16,7 +16,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
         _map.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -74,7 +74,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              kvp._2
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -96,7 +96,7 @@ case class ComplexLogicalTypesDisabled(var _map: Map[String, String], var _array
               m.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  kvp._2
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }

--- a/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
@@ -11,14 +11,14 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
   override def get(field$: Int): AnyRef = {
     (field$: @switch) match {
-      case 0 => {_uuid.toString}.asInstanceOf[AnyRef]
-      case 1 => {_date.toEpochDay.toInt}.asInstanceOf[AnyRef]
-      case 2 => {(_time_millis.toNanoOfDay / 1000000L).toInt}.asInstanceOf[AnyRef]
-      case 3 => {_time_micros.toNanoOfDay / 1000L}.asInstanceOf[AnyRef]
-      case 4 => {_timestamp_millis.toEpochMilli}.asInstanceOf[AnyRef]
-      case 5 => {(_timestamp_micros.getEpochSecond * 1000000L) + (_timestamp_micros.getNano / 1000L)}.asInstanceOf[AnyRef]
-      case 6 => {_local_timestamp_millis.atZone(java.time.ZoneId.of("UTC")).toInstant.toEpochMilli}.asInstanceOf[AnyRef]
-      case 7 => {_local_timestamp_micros.atZone(java.time.ZoneId.of("UTC")).toInstant.getEpochSecond * 1000000L + _local_timestamp_micros.atZone(java.time.ZoneId.of("UTC")).toInstant.getNano / 1000L}.asInstanceOf[AnyRef]
+      case 0 => _uuid.asInstanceOf[AnyRef]
+      case 1 => _date.asInstanceOf[AnyRef]
+      case 2 => _time_millis.asInstanceOf[AnyRef]
+      case 3 => _time_micros.asInstanceOf[AnyRef]
+      case 4 => _timestamp_millis.asInstanceOf[AnyRef]
+      case 5 => _timestamp_micros.asInstanceOf[AnyRef]
+      case 6 => _local_timestamp_millis.asInstanceOf[AnyRef]
+      case 7 => _local_timestamp_micros.asInstanceOf[AnyRef]
       case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
     }
   }
@@ -26,30 +26,44 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
   override def put(field$: Int, value: Any): Unit = {
     (field$: @switch) match {
       case 0 => this._uuid = {
-        {java.util.UUID.fromString(value.toString.asInstanceOf[String])}
+        value.asInstanceOf[java.util.UUID]
       }
       case 1 => this._date = {
-        {java.time.LocalDate.ofEpochDay(value.asInstanceOf[Int])}
+        value.asInstanceOf[java.time.LocalDate]
       }
       case 2 => this._time_millis = {
-        {java.time.LocalTime.ofNanoOfDay(value.asInstanceOf[Int] * 1000000L)}
+        value.asInstanceOf[java.time.LocalTime]
       }
       case 3 => this._time_micros = {
-        {java.time.LocalTime.ofNanoOfDay(value.asInstanceOf[Long] * 1000L)}
+        value.asInstanceOf[java.time.LocalTime]
       }
       case 4 => this._timestamp_millis = {
-        {java.time.Instant.ofEpochMilli(value.asInstanceOf[Long])}
+        value.asInstanceOf[java.time.Instant]
       }
       case 5 => this._timestamp_micros = {
-        {java.time.Instant.ofEpochSecond(value.asInstanceOf[Long] / 1000000L, (value.asInstanceOf[Long] % 1000000L) * 1000L)}
+        value.asInstanceOf[java.time.Instant]
       }
       case 6 => this._local_timestamp_millis = {
-        {java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(value.asInstanceOf[Long]), java.time.ZoneId.of("UTC"))}
+        value.asInstanceOf[java.time.LocalDateTime]
       }
       case 7 => this._local_timestamp_micros = {
-        {java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(value.asInstanceOf[Long] / 1000000L, (value.asInstanceOf[Long] % 1000000L) * 1000L), java.time.ZoneId.of("UTC"))}
+        value.asInstanceOf[java.time.LocalDateTime]
       }
       case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def getConversion(field: Int): org.apache.avro.Conversion[?] = {
+    (field: @switch) match {
+      case 0 => new org.apache.avro.Conversions.UUIDConversion()
+      case 1 => new org.apache.avro.data.TimeConversions.DateConversion()
+      case 2 => new org.apache.avro.data.TimeConversions.TimeMillisConversion()
+      case 3 => new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
+      case 4 => new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
+      case 5 => new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
+      case 6 => new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
+      case 7 => new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
+      case _ => null
     }
   }
 }

--- a/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
@@ -57,14 +57,14 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
   override def getConversion(field: Int): org.apache.avro.Conversion[?] = {
     (field: @switch) match {
-      case 0 => LogicalTypes._uuid$Conversion
-      case 1 => LogicalTypes._date$Conversion
-      case 2 => LogicalTypes._time_millis$Conversion
-      case 3 => LogicalTypes._time_micros$Conversion
-      case 4 => LogicalTypes._timestamp_millis$Conversion
-      case 5 => LogicalTypes._timestamp_micros$Conversion
-      case 6 => LogicalTypes._local_timestamp_millis$Conversion
-      case 7 => LogicalTypes._local_timestamp_micros$Conversion
+      case 0 => LogicalTypes.$UUIDConversion
+      case 1 => LogicalTypes.$DateConversion
+      case 2 => LogicalTypes.$TimeMillisConversion
+      case 3 => LogicalTypes.$TimeMicrosConversion
+      case 4 => LogicalTypes.$TimestampMillisConversion
+      case 5 => LogicalTypes.$TimestampMicrosConversion
+      case 6 => LogicalTypes.$LocalTimestampMillisConversion
+      case 7 => LogicalTypes.$LocalTimestampMicrosConversion
       case _ => null
     }
   }
@@ -72,24 +72,24 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
 object LogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}""")
+  val $UUIDConversion: org.apache.avro.Conversion[?] = new org.apache.avro.Conversions.UUIDConversion()
+  val $DateConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.DateConversion()
+  val $TimeMillisConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()
+  val $TimeMicrosConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
+  val $TimestampMillisConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
+  val $TimestampMicrosConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
+  val $LocalTimestampMillisConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
+  val $LocalTimestampMicrosConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
   val MODEL$: org.apache.avro.specific.SpecificData = {
     val model = new org.apache.avro.specific.SpecificData()
-    model.addLogicalTypeConversion(new org.apache.avro.Conversions.UUIDConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.DateConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMicrosConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMicrosConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion())
-    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion())
+    model.addLogicalTypeConversion($UUIDConversion)
+    model.addLogicalTypeConversion($DateConversion)
+    model.addLogicalTypeConversion($TimeMillisConversion)
+    model.addLogicalTypeConversion($TimeMicrosConversion)
+    model.addLogicalTypeConversion($TimestampMillisConversion)
+    model.addLogicalTypeConversion($TimestampMicrosConversion)
+    model.addLogicalTypeConversion($LocalTimestampMillisConversion)
+    model.addLogicalTypeConversion($LocalTimestampMicrosConversion)
     model
   }
-  val _uuid$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.Conversions.UUIDConversion()
-  val _date$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.DateConversion()
-  val _time_millis$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()
-  val _time_micros$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
-  val _timestamp_millis$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
-  val _timestamp_micros$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
-  val _local_timestamp_millis$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
-  val _local_timestamp_micros$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
 }

--- a/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
@@ -55,14 +55,14 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
   override def getConversion(field: Int): org.apache.avro.Conversion[?] = {
     (field: @switch) match {
-      case 0 => new org.apache.avro.Conversions.UUIDConversion()
-      case 1 => new org.apache.avro.data.TimeConversions.DateConversion()
-      case 2 => new org.apache.avro.data.TimeConversions.TimeMillisConversion()
-      case 3 => new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
-      case 4 => new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
-      case 5 => new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
-      case 6 => new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
-      case 7 => new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
+      case 0 => LogicalTypes._uuid$Conversion
+      case 1 => LogicalTypes._date$Conversion
+      case 2 => LogicalTypes._time_millis$Conversion
+      case 3 => LogicalTypes._time_micros$Conversion
+      case 4 => LogicalTypes._timestamp_millis$Conversion
+      case 5 => LogicalTypes._timestamp_micros$Conversion
+      case 6 => LogicalTypes._local_timestamp_millis$Conversion
+      case 7 => LogicalTypes._local_timestamp_micros$Conversion
       case _ => null
     }
   }
@@ -70,4 +70,12 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
 object LogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}""")
+  val _uuid$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.Conversions.UUIDConversion()
+  val _date$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.DateConversion()
+  val _time_millis$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()
+  val _time_micros$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimeMicrosConversion()
+  val _timestamp_millis$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimestampMillisConversion()
+  val _timestamp_micros$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
+  val _local_timestamp_millis$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
+  val _local_timestamp_micros$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
 }

--- a/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
@@ -9,6 +9,8 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
   override def getSchema: org.apache.avro.Schema = LogicalTypes.SCHEMA$
 
+  override def getSpecificData(): org.apache.avro.specific.SpecificData = LogicalTypes.MODEL$
+
   override def get(field$: Int): AnyRef = {
     (field$: @switch) match {
       case 0 => _uuid.asInstanceOf[AnyRef]
@@ -70,6 +72,18 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
 
 object LogicalTypes {
   val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}""")
+  val MODEL$: org.apache.avro.specific.SpecificData = {
+    val model = new org.apache.avro.specific.SpecificData()
+    model.addLogicalTypeConversion(new org.apache.avro.Conversions.UUIDConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.DateConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimeMicrosConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.TimestampMicrosConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion())
+    model.addLogicalTypeConversion(new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion())
+    model
+  }
   val _uuid$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.Conversions.UUIDConversion()
   val _date$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.DateConversion()
   val _time_millis$Conversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()

--- a/avro2s/src/test/scala-3/avro2s/test/maps/Fixed.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/maps/Fixed.scala
@@ -15,8 +15,8 @@ case class Fixed() extends org.apache.avro.specific.SpecificFixed {
 
 object Fixed {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"Fixed","namespace":"avro2s.test.maps","size":2}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed](Fixed.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed](Fixed.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed](Fixed.SCHEMA$, Fixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed](Fixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): Fixed = {
     val fixed = new avro2s.test.maps.Fixed()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-3/avro2s/test/maps/Maps.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/maps/Maps.scala
@@ -20,7 +20,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
             kvp._2.foreach { kvp =>
               val key = kvp._1
               val value = {
-                kvp._2
+                kvp._2.asInstanceOf[AnyRef]
               }
               map.put(key, value)
             }
@@ -110,7 +110,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
                 m.foreach { kvp =>
                   val key = kvp._1
                   val value = {
-                    kvp._2
+                    kvp._2.asInstanceOf[AnyRef]
                   }
                   map.put(key, value)
                 }
@@ -175,7 +175,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_fixed.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -186,7 +186,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_enum.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -197,7 +197,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_record.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -234,7 +234,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_string.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -245,7 +245,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_int.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -256,7 +256,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_long.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -267,7 +267,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_float.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -278,7 +278,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_double.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -289,7 +289,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_boolean.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }
@@ -300,7 +300,7 @@ case class Maps(var _map_of_maps: Map[String, Map[String, String]], var _map_of_
         _map_of_null.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }

--- a/avro2s/src/test/scala-3/avro2s/test/namespaces/explicit/RecordWithExplicitNamespace.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/namespaces/explicit/RecordWithExplicitNamespace.scala
@@ -26,7 +26,7 @@ case class RecordWithExplicitNamespace(var _string: String, var _record_with_nam
         _map_of_records.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }

--- a/avro2s/src/test/scala-3/avro2s/test/spec/AvroSpec.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/spec/AvroSpec.scala
@@ -33,7 +33,7 @@ case class AvroSpec(var _null: scala.Null, var _boolean: Boolean, var _int: Int,
         _map.foreach { kvp =>
           val key = kvp._1
           val value = {
-            kvp._2
+            kvp._2.asInstanceOf[AnyRef]
           }
           map.put(key, value)
         }

--- a/avro2s/src/test/scala-3/avro2s/test/spec/md5.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/spec/md5.scala
@@ -15,8 +15,8 @@ case class md5() extends org.apache.avro.specific.SpecificFixed {
 
 object md5 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"md5","namespace":"avro2s.test.spec","size":16}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[md5](md5.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[md5](md5.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[md5](md5.SCHEMA$, md5.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[md5](md5.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): md5 = {
     val fixed = new avro2s.test.spec.md5()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-3/avro2s/test/unions/ComplexOptions.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/unions/ComplexOptions.scala
@@ -36,7 +36,7 @@ case class ComplexOptions(var _map_of_option_of_record: Map[String, Option[avro2
                 x.foreach { kvp =>
                   val key = kvp._1
                   val value = {
-                    kvp._2
+                    kvp._2.asInstanceOf[AnyRef]
                   }
                   map.put(key, value)
                 }
@@ -84,7 +84,7 @@ case class ComplexOptions(var _map_of_option_of_record: Map[String, Option[avro2
                 x.foreach { kvp =>
                   val key = kvp._1
                   val value = {
-                    kvp._2
+                    kvp._2.asInstanceOf[AnyRef]
                   }
                   map.put(key, value)
                 }

--- a/avro2s/src/test/scala-3/avro2s/test/unions/Fixed1.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/unions/Fixed1.scala
@@ -15,8 +15,8 @@ case class Fixed1() extends org.apache.avro.specific.SpecificFixed {
 
 object Fixed1 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"Fixed1","namespace":"avro2s.test.unions","size":1}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed1](Fixed1.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed1](Fixed1.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed1](Fixed1.SCHEMA$, Fixed1.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed1](Fixed1.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): Fixed1 = {
     val fixed = new avro2s.test.unions.Fixed1()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-3/avro2s/test/unions/Fixed2.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/unions/Fixed2.scala
@@ -15,8 +15,8 @@ case class Fixed2() extends org.apache.avro.specific.SpecificFixed {
 
 object Fixed2 {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"Fixed2","namespace":"avro2s.test.unions","size":1}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed2](Fixed2.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed2](Fixed2.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[Fixed2](Fixed2.SCHEMA$, Fixed2.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[Fixed2](Fixed2.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): Fixed2 = {
     val fixed = new avro2s.test.unions.Fixed2()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-3/avro2s/test/unions/FixedForComplexOptions.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/unions/FixedForComplexOptions.scala
@@ -15,8 +15,8 @@ case class FixedForComplexOptions() extends org.apache.avro.specific.SpecificFix
 
 object FixedForComplexOptions {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"FixedForComplexOptions","namespace":"avro2s.test.unions","size":16}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedForComplexOptions](FixedForComplexOptions.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedForComplexOptions](FixedForComplexOptions.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[FixedForComplexOptions](FixedForComplexOptions.SCHEMA$, FixedForComplexOptions.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[FixedForComplexOptions](FixedForComplexOptions.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): FixedForComplexOptions = {
     val fixed = new avro2s.test.unions.FixedForComplexOptions()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-3/avro2s/test/unions/Unions.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/unions/Unions.scala
@@ -210,7 +210,7 @@ case class Unions(var _union_of_map_of_union: Option[String | Long | Boolean | M
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              kvp._2
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -250,7 +250,7 @@ case class Unions(var _union_of_map_of_union: Option[String | Long | Boolean | M
           x.foreach { kvp =>
             val key = kvp._1
             val value = {
-              kvp._2
+              kvp._2.asInstanceOf[AnyRef]
             }
             map.put(key, value)
           }
@@ -269,7 +269,7 @@ case class Unions(var _union_of_map_of_union: Option[String | Long | Boolean | M
               kvp._2.foreach { kvp =>
                 val key = kvp._1
                 val value = {
-                  kvp._2
+                  kvp._2.asInstanceOf[AnyRef]
                 }
                 map.put(key, value)
               }

--- a/avro2s/src/test/scala/avro2s/serialization/SerializationHelpers.scala
+++ b/avro2s/src/test/scala/avro2s/serialization/SerializationHelpers.scala
@@ -2,7 +2,7 @@ package avro2s.serialization
 
 import org.apache.avro.Schema
 import org.apache.avro.io.{BinaryDecoder, BinaryEncoder, DecoderFactory, EncoderFactory}
-import org.apache.avro.specific.{SpecificDatumReader, SpecificDatumWriter, SpecificRecordBase}
+import org.apache.avro.specific.{SpecificData, SpecificDatumReader, SpecificDatumWriter, SpecificRecordBase}
 
 import java.io.ByteArrayOutputStream
 
@@ -18,8 +18,25 @@ object SerializationHelpers {
     out.toByteArray
   }
 
+  def serializeWithoutConversions[T <: SpecificRecordBase](data: T): Array[Byte] = {
+    val writer = new SpecificDatumWriter[T](data.getSchema, new SpecificData())
+    val out = new ByteArrayOutputStream()
+    val encoder: BinaryEncoder = EncoderFactory.get().binaryEncoder(out, null)
+
+    writer.write(data, encoder)
+    encoder.flush()
+    out.close()
+    out.toByteArray
+  }
+
   def deserialize[T <: SpecificRecordBase](bytes: Array[Byte], schema: Schema): T = {
     val reader = new SpecificDatumReader[T](schema)
+    val decoder: BinaryDecoder = DecoderFactory.get().binaryDecoder(bytes, null)
+    reader.read(null.asInstanceOf[T], decoder)
+  }
+
+  def deserializeWithoutConversions[T <: SpecificRecordBase](bytes: Array[Byte], schema: Schema): T = {
+    val reader = new SpecificDatumReader[T](schema, schema, new SpecificData())
     val decoder: BinaryDecoder = DecoderFactory.get().binaryDecoder(bytes, null)
     reader.read(null.asInstanceOf[T], decoder)
   }

--- a/build.sbt
+++ b/build.sbt
@@ -84,5 +84,5 @@ lazy val sbtAvro2s = (projectMatrix in file("sbt-avro2s"))
   .enablePlugins(SbtPlugin)
 
 lazy val versions = new {
-  val avro = "1.11.4"
+  val avro = "1.12.1"
 }

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / version := "1.0.0-SNAPSHOT"
+ThisBuild / version := "0.25.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "2.13.16"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / version := "0.24.0-SNAPSHOT"
+ThisBuild / version := "1.0.0-SNAPSHOT"
 
 ThisBuild / scalaVersion := "2.13.16"
 


### PR DESCRIPTION
## Summary

Upgrades generated code to support Avro 1.12 exclusively (drops 1.11 backward compatibility). This is a breaking change, hence the bump to version 1.0.0.

### What changed

**Avro 1.12 compatibility** (commits 1-2)
- Avro 1.12 ([AVRO-3989](https://issues.apache.org/jira/browse/AVRO-3989)) pre-registers logical type conversions on the default `SpecificData` singleton, causing `ClassCastException` in `put()` when generated code expected raw primitives
- Generate `override getConversion(field: Int)` returning the appropriate `Conversion` per field, letting Avro handle type conversion natively
- Update `get()` and `put()` to work with logical types directly for top-level fields
- Use `new SpecificData()` for Fixed types and "logical types disabled" tests to bypass pre-registered conversions

**Drop 1.11 backward compatibility, bump to 1.0.0** (commit 3)
- Remove accept-both pattern matching in `put()` that handled both raw and converted types
- Simplify generated code to only handle Avro 1.12 semantics
- Bump version from 0.24.0-SNAPSHOT to 1.0.0-SNAPSHOT

**Generate MODEL$ with all logical type conversions** (commit 4)
- Generate a per-class `MODEL$` (`SpecificData` instance) with all supported logical type conversions registered unconditionally, matching Avro's Java codegen pattern
- Generate `override getSpecificData()` returning `MODEL$` so reader/writer use it for nested element conversion via `getData().getConversionFor()`
- Simplify nested `get()` in `GetCaseGenerator` (Scala 2 & 3) — no longer manually converts logical types inline; delegates to the writer via MODEL$
- Fix flaky `SerializationTest` timestamp-millis precision on Java 21

**Conversion cleanup follow-up** (commits 5-9)
- Replace per-field `$fieldName$Conversion` vals with one shared `$ClassName` val per distinct conversion type — eliminates duplicate instances when multiple fields share the same type
- Filter MODEL$ to only register conversions actually used in the schema (previously registered all 8 unconditionally), with recursive traversal into MAP/ARRAY/UNION for nested logical types
- Gate `getConversion` explicitly on `logicalTypesEnabled` (previously relied implicitly on the empty map)
- Use `logicalTypeInUse` consistently as the boolean predicate throughout; `getConversionClass` called only where the class name string is needed
- Merge `printConversionVals` + `printModel` into single `printConversionInfrastructure` — one computation of distinct conversions, one guard, vals and MODEL$ always in sync
- Only emit `getSpecificData()` override when the schema actually uses logical types

### Context

- [AVRO-3989](https://issues.apache.org/jira/browse/AVRO-3989): Adds conversion classes to default `SpecificData` instance
- [AVRO-3536](https://issues.apache.org/jira/browse/AVRO-3536): Union types now inherit conversions
- [AVRO-3230](https://issues.apache.org/jira/browse/AVRO-3230): FastReader enabled by default in 1.12.1

## Test plan
- [x] `sbt test` — all 83 tests pass across Scala 2.12, 2.13, and 3
- [x] Serialization round-trip tests for logical types (enabled and disabled)
- [x] Standalone Fixed type serialization round-trip test
- [x] Code generation output matches expected fixtures

🤖 Generated with [Claude Code](https://claude.com/claude-code)