### PR TITLE
feat: add timestamp-nanos, decimal, duration, and big-decimal logical types

### DIFF
--- a/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
+++ b/avro2s/src/main/scala/avro2s/generator/logical/LogicalTypes.scala
@@ -46,6 +46,11 @@ private[avro2s] object LogicalTypes {
       }.getOrElse(default)
     }
     
+    def avroAutoConverts(schema: Schema): Boolean = Option(schema.getLogicalType).exists { logicalType =>
+      val key = LogicalTypeKey(schema.getType, logicalType.getName)
+      logicalTypeMap.get(key).exists(lt => lt.validate(schema) && lt.avroAutoConverts)
+    }
+
     def logicalTypeInUse(schema: Schema): Boolean = Option(schema.getLogicalType).exists { logicalType =>
       val schemaType = schema.getType
       val logicalTypeName = logicalType.getName
@@ -56,7 +61,7 @@ private[avro2s] object LogicalTypes {
     def getConversionClass(schema: Schema): Option[String] = {
       Option(schema.getLogicalType).flatMap { logicalType =>
         val key = LogicalTypeKey(schema.getType, logicalType.getName)
-        logicalTypeMap.get(key).filter(_.validate(schema)).map(_.conversionClass)
+        logicalTypeMap.get(key).filter(_.validate(schema)).map(_.conversionClass).filter(_.nonEmpty)
       }
     }
 
@@ -96,6 +101,11 @@ private[avro2s] object LogicalTypes {
     def defaultValue(schema: Schema): String
 
     def conversionClass: String
+
+    /** True if Avro automatically converts this BYTES-backed type to the target Scala type
+     *  before calling put(), meaning put() receives the target type directly rather than a ByteBuffer.
+     */
+    def avroAutoConverts: Boolean = false
   }
 
   case object UUID extends LogicalType("uuid", Set(STRING)) {
@@ -194,32 +204,106 @@ private[avro2s] object LogicalTypes {
     override def conversionClass: String = "org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion"
   }
 
-  // TODO: implement decimal
-  case object Decimal extends LogicalType("decimal", Set(BYTES, FIXED)) {
-    override def toType(value: String, schema: Schema): String = ???
+  case object TimestampNanosecondPrecision extends LogicalType("timestamp-nanos", Set(LONG)) {
+    override def toType(value: String, schema: Schema): String =
+      s"java.time.Instant.ofEpochSecond($value / 1_000_000_000L, $value % 1_000_000_000L)"
 
-    override def fromType(value: String, schema: Schema): String = ???
+    override def fromType(value: String, schema: Schema): String =
+      s"$value.getEpochSecond * 1_000_000_000L + $value.getNano"
 
-    override def getType(schema: Schema): String = ???
+    override def getType(schema: Schema): String = "java.time.Instant"
 
-    override def defaultValue(schema: Schema): String = ???
+    override def defaultValue(schema: Schema): String = "java.time.Instant.ofEpochSecond(0L, 0L)"
 
-    override def conversionClass: String = ???
+    override def conversionClass: String = "org.apache.avro.data.TimeConversions.TimestampNanosConversion"
   }
 
-  // TODO: Implement duration
+  case object LocalTimestampNanosecondPrecision extends LogicalType("local-timestamp-nanos", Set(LONG)) {
+    override def toType(value: String, schema: Schema): String =
+      s"java.time.LocalDateTime.ofEpochSecond($value / 1_000_000_000L, ($value % 1_000_000_000L).toInt, java.time.ZoneOffset.UTC)"
+
+    override def fromType(value: String, schema: Schema): String =
+      s"$value.toEpochSecond(java.time.ZoneOffset.UTC) * 1_000_000_000L + $value.getNano"
+
+    override def getType(schema: Schema): String = "java.time.LocalDateTime"
+
+    override def defaultValue(schema: Schema): String =
+      "java.time.LocalDateTime.ofEpochSecond(0L, 0, java.time.ZoneOffset.UTC)"
+
+    override def conversionClass: String = "org.apache.avro.data.TimeConversions.LocalTimestampNanosConversion"
+  }
+
+  case object Decimal extends LogicalType("decimal", Set(BYTES, FIXED)) {
+    override def toType(value: String, schema: Schema): String = {
+      val scale = Option(schema.getLogicalType)
+        .collect { case d: org.apache.avro.LogicalTypes.Decimal => d }
+        .map(_.getScale)
+        .getOrElse(0)
+      if (schema.getType == FIXED)
+        s"scala.math.BigDecimal(new java.math.BigDecimal(new java.math.BigInteger($value.asInstanceOf[org.apache.avro.generic.GenericFixed].bytes()), $scale))"
+      else
+        s"scala.math.BigDecimal(new java.math.BigDecimal(new java.math.BigInteger($value.array()), $scale))"
+    }
+
+    override def fromType(value: String, schema: Schema): String = {
+      val scale = Option(schema.getLogicalType)
+        .collect { case d: org.apache.avro.LogicalTypes.Decimal => d }
+        .map(_.getScale)
+        .getOrElse(0)
+      if (schema.getType == FIXED) {
+        val fixedSize = schema.getFixedSize
+        val fullName = schema.getFullName
+        s"""val unscaled = $value.setScale($scale).bigDecimal.unscaledValue().toByteArray; if (unscaled.length > $fixedSize) throw new ArithmeticException("Decimal value does not fit in " + $fixedSize + " bytes: requires " + unscaled.length + " bytes"); val padded = new Array[Byte]($fixedSize); val fillByte: Byte = if (unscaled.length > 0 && unscaled(0) < 0) 0xFF.toByte else 0x00.toByte; java.util.Arrays.fill(padded, fillByte); System.arraycopy(unscaled, 0, padded, $fixedSize - unscaled.length, unscaled.length); val result = new $fullName(); result.bytes(padded); result"""
+      } else
+        s"java.nio.ByteBuffer.wrap($value.setScale($scale).bigDecimal.unscaledValue().toByteArray)"
+    }
+
+    override def getType(schema: Schema): String = "scala.math.BigDecimal"
+
+    override def defaultValue(schema: Schema): String = "scala.math.BigDecimal(0)"
+
+    override def conversionClass: String = ""
+
+    override def validate(schema: Schema): Boolean =
+      Option(schema.getLogicalType).exists(_.isInstanceOf[org.apache.avro.LogicalTypes.Decimal])
+  }
+
+  case object AvroJavaBigDecimal extends LogicalType("big-decimal", Set(BYTES)) {
+    override def toType(value: String, schema: Schema): String =
+      s"$value.asInstanceOf[java.math.BigDecimal]"
+
+    override def fromType(value: String, schema: Schema): String =
+      s"new org.apache.avro.Conversions.BigDecimalConversion().toBytes($value, null, null)"
+
+    override def getType(schema: Schema): String = "java.math.BigDecimal"
+
+    override def defaultValue(schema: Schema): String = "java.math.BigDecimal.ZERO"
+
+    override def validate(schema: Schema): Boolean = schema.getType == BYTES
+
+    override def conversionClass: String = ""
+
+    override def avroAutoConverts: Boolean = true
+  }
+
   case object Duration extends LogicalType("duration", Set(FIXED)) {
-    override def toType(value: String, schema: Schema): String = ???
+    override def toType(value: String, schema: Schema): String =
+      s"$value.asInstanceOf[org.apache.avro.util.TimePeriod]"
 
-    override def fromType(value: String, schema: Schema): String = ???
+    override def fromType(value: String, schema: Schema): String = {
+      val fullName = schema.getFullName
+      s"new org.apache.avro.Conversions.DurationConversion().toFixed($value, $fullName.SCHEMA$$, $fullName.SCHEMA$$.getLogicalType)"
+    }
 
-    override def getType(schema: Schema): String = ???
+    override def getType(schema: Schema): String = "org.apache.avro.util.TimePeriod"
 
     override def validate(schema: Schema): Boolean = schema.getFixedSize == 12
 
-    override def defaultValue(schema: Schema): String = ???
+    override def defaultValue(schema: Schema): String = "org.apache.avro.util.TimePeriod.of(0L, 0L, 0L)"
 
-    override def conversionClass: String = ???
+    override def conversionClass: String = ""
+
+    override def avroAutoConverts: Boolean = true
   }
 
   private val supportedLogicalTypes: List[LogicalType] = List(
@@ -230,7 +314,12 @@ private[avro2s] object LogicalTypes {
     TimestampMillisecondPrecision,
     TimestampMicrosecondPrecision,
     LocalTimestampMillisecondPrecision,
-    LocalTimestampMicrosecondPrecision
+    LocalTimestampMicrosecondPrecision,
+    TimestampNanosecondPrecision,
+    LocalTimestampNanosecondPrecision,
+    Decimal,
+    Duration,
+    AvroJavaBigDecimal
   )
 
   case class LogicalTypeKey(schemaType: Type, logicalTypeName: String)

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/GetCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/GetCaseGenerator.scala
@@ -22,9 +22,17 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
       case MAP => printMapCase(printer, index, field)
       case ARRAY => printArrayCase(printer, index, field)
       case BYTES => printByteCase(printer, index, field)
+      case FIXED => printFixedCase(printer, index, field)
       case _ => printDefaultCase(printer, index, field)
     }
   }
+
+  private def printFixedCase(printer: FunctionalPrinter, index: Int, field: Schema.Field): FunctionalPrinter =
+    if (ltc.logicalTypeInUse(field.schema())) {
+      printer.add(s"case $index => ${ltc.fromType(field.schema(), field.safeName)}.asInstanceOf[AnyRef]")
+    } else {
+      printer.add(s"case $index => ${field.safeName}.asInstanceOf[AnyRef]")
+    }
 
   private def printUnionCase(printer: FunctionalPrinter, index: Int, field: Schema.Field): FunctionalPrinter =
     printer

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/PutCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/PutCaseGenerator.scala
@@ -28,6 +28,9 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
           .call(matchUnion(_, "value", field.schema()))
           .outdent
           .add("}")
+      case BYTES if ltc.avroAutoConverts(field.schema()) =>
+        printer
+          .add(s"case $index => this.${field.safeName} = value.asInstanceOf[${ltc.getType(field.schema(), schemaToScalaType(field.schema, false))}]")
       case BYTES =>
         printer
           .add(s"case $index => this.${field.safeName} = {")

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/GetCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/GetCaseGenerator.scala
@@ -22,9 +22,17 @@ private[avro2s] class GetCaseGenerator(ltc: LogicalTypeConverter) {
       case MAP => printMapCase(printer, index, field)
       case ARRAY => printArrayCase(printer, index, field)
       case BYTES => printByteCase(printer, index, field)
+      case FIXED => printFixedCase(printer, index, field)
       case _ => printDefaultCase(printer, index, field)
     }
   }
+
+  private def printFixedCase(printer: FunctionalPrinter, index: Int, field: Schema.Field): FunctionalPrinter =
+    if (ltc.logicalTypeInUse(field.schema())) {
+      printer.add(s"case $index => ${ltc.fromType(field.schema(), field.safeName)}.asInstanceOf[AnyRef]")
+    } else {
+      printer.add(s"case $index => ${field.safeName}.asInstanceOf[AnyRef]")
+    }
 
   private def printUnionCase(printer: FunctionalPrinter, index: Int, field: Schema.Field): FunctionalPrinter =
     printer

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/PutCaseGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/PutCaseGenerator.scala
@@ -25,6 +25,8 @@ private[avro2s] class PutCaseGenerator(ltc: LogicalTypeConverter) {
         field.schema().getType match {
           case UNION =>
             printer.call(asUnion(_, "value", field.schema()))
+          case BYTES if ltc.avroAutoConverts(field.schema()) =>
+            printer.add(s"value.asInstanceOf[${ltc.getType(field.schema(), schemaToScalaType(field.schema(), false))}]")
           case BYTES =>
             printer.call(asBytes(_, "value", field.schema()))
           case MAP =>

--- a/avro2s/src/test/resources/input/logical-enabled/logical/logical-duration.avsc
+++ b/avro2s/src/test/resources/input/logical-enabled/logical/logical-duration.avsc
@@ -1,0 +1,16 @@
+{
+  "type": "record",
+  "namespace": "avro2s.test.logical",
+  "name": "LogicalDuration",
+  "fields": [
+    {
+      "name": "_duration",
+      "type": {
+        "type": "fixed",
+        "name": "DurationFixed",
+        "size": 12,
+        "logicalType": "duration"
+      }
+    }
+  ]
+}

--- a/avro2s/src/test/resources/input/logical-enabled/logical/logical-fixed-decimal.avsc
+++ b/avro2s/src/test/resources/input/logical-enabled/logical/logical-fixed-decimal.avsc
@@ -1,0 +1,18 @@
+{
+  "type": "record",
+  "namespace": "avro2s.test.logical",
+  "name": "LogicalFixedDecimal",
+  "fields": [
+    {
+      "name": "_decimal_fixed",
+      "type": {
+        "type": "fixed",
+        "name": "DecimalFixed",
+        "size": 2,
+        "logicalType": "decimal",
+        "precision": 4,
+        "scale": 2
+      }
+    }
+  ]
+}

--- a/avro2s/src/test/resources/input/logical-enabled/logical/logical.avsc
+++ b/avro2s/src/test/resources/input/logical-enabled/logical/logical.avsc
@@ -58,6 +58,36 @@
         "type": "long",
         "logicalType": "local-timestamp-micros"
       }
+    },
+    {
+      "name": "_timestamp_nanos",
+      "type": {
+        "type": "long",
+        "logicalType": "timestamp-nanos"
+      }
+    },
+    {
+      "name": "_local_timestamp_nanos",
+      "type": {
+        "type": "long",
+        "logicalType": "local-timestamp-nanos"
+      }
+    },
+    {
+      "name": "_decimal",
+      "type": {
+        "type": "bytes",
+        "logicalType": "decimal",
+        "precision": 10,
+        "scale": 2
+      }
+    },
+    {
+      "name": "_big_decimal",
+      "type": {
+        "type": "bytes",
+        "logicalType": "big-decimal"
+      }
     }
   ]
 }

--- a/avro2s/src/test/scala-2.13/avro2s/generator/CodeGeneratorTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/CodeGeneratorTest.scala
@@ -172,6 +172,24 @@ class CodeGeneratorTest extends AnyFunSuite with Matchers {
     tripleQuotedSegments.foreach(seg => seg.length should be <= 65000)
   }
 
+  test("logical fixed decimal types should produce expected output") {
+    val code = generateCode("input/logical-enabled/logical/logical-fixed-decimal.avsc", logicalTypesEnabled = true)
+
+    code.foreach { code =>
+      val expectedCode = loadTestCode("logical", code.path.split("/").last)
+      testResult(code, expectedCode)
+    }
+  }
+
+  test("logical duration types should produce expected output") {
+    val code = generateCode("input/logical-enabled/logical/logical-duration.avsc", logicalTypesEnabled = true)
+
+    code.foreach { code =>
+      val expectedCode = loadTestCode("logical", code.path.split("/").last)
+      testResult(code, expectedCode)
+    }
+  }
+
   def generateCode(path: String, logicalTypesEnabled: Boolean = false): List[GeneratedCode] = {
     val generatorConfig = GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled)
     

--- a/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
@@ -286,12 +286,44 @@ class SerializationTest extends AnyFunSuite with Matchers {
       _timestamp_millis = java.time.Instant.ofEpochMilli(1234567890123L),
       _timestamp_micros = java.time.Instant.ofEpochSecond(1234567890L, 123456000L),
       _local_timestamp_millis = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(1234567890123L), java.time.ZoneOffset.UTC),
-      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(1234567890L, 123456000L), java.time.ZoneOffset.UTC)
+      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(1234567890L, 123456000L), java.time.ZoneOffset.UTC),
+      _timestamp_nanos = java.time.Instant.ofEpochSecond(1234567890L, 123456789L),
+      _local_timestamp_nanos = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(1234567890L, 123456789L), java.time.ZoneOffset.UTC),
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     deserialize[avro2s.test.logical.LogicalTypes](serialize(logicalTypes), logicalTypes.getSchema) shouldBe logicalTypes
   }
   
+  test("logical fixed decimal can be serialized and deserialized") {
+    val logicalFixedDecimal = avro2s.test.logical.LogicalFixedDecimal(
+      _decimal_fixed = scala.math.BigDecimal("12.34")
+    )
+    deserialize[avro2s.test.logical.LogicalFixedDecimal](serialize(logicalFixedDecimal), logicalFixedDecimal.getSchema) shouldBe logicalFixedDecimal
+  }
+
+  test("logical fixed decimal handles negative values via sign extension") {
+    val negative = avro2s.test.logical.LogicalFixedDecimal(
+      _decimal_fixed = scala.math.BigDecimal("-12.34")
+    )
+    deserialize[avro2s.test.logical.LogicalFixedDecimal](serialize(negative), negative.getSchema) shouldBe negative
+  }
+
+  test("logical fixed decimal rejects values that do not fit in the fixed size") {
+    val tooLarge = avro2s.test.logical.LogicalFixedDecimal(
+      _decimal_fixed = scala.math.BigDecimal("99999.99")
+    )
+    an[ArithmeticException] should be thrownBy serialize(tooLarge)
+  }
+
+  test("logical duration can be serialized and deserialized") {
+    val logicalDuration = avro2s.test.logical.LogicalDuration(
+      _duration = org.apache.avro.util.TimePeriod.of(1L, 2L, 3L)
+    )
+    deserialize[avro2s.test.logical.LogicalDuration](serialize(logicalDuration), logicalDuration.getSchema) shouldBe logicalDuration
+  }
+
   test("logical types disabled can be serialized and deserialized") {
     val logicalTypesDisabled = avro2s.test.logical.LogicalTypesDisabled(
       _uuid = "550e8400-e29b-41d4-a716-446655440000",

--- a/avro2s/src/test/scala-2.13/avro2s/generator/logical/LogicalTypesTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/logical/LogicalTypesTest.scala
@@ -17,6 +17,8 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
   private val fixedTimestampMicros = java.time.Instant.ofEpochSecond(1234567890L, 123456000L)
   private val fixedLocalTimestampMillis = java.time.LocalDateTime.ofInstant(fixedTimestampMillis, java.time.ZoneOffset.UTC)
   private val fixedLocalTimestampMicros = java.time.LocalDateTime.ofInstant(fixedTimestampMicros, java.time.ZoneOffset.UTC)
+  private val fixedTimestampNanos = java.time.Instant.ofEpochSecond(1234567890L, 123456789L)
+  private val fixedLocalTimestampNanos = java.time.LocalDateTime.ofInstant(fixedTimestampNanos, java.time.ZoneOffset.UTC)
 
   test("time-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
@@ -27,7 +29,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
@@ -55,7 +61,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
@@ -83,7 +93,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = time,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfEpoch = java.time.Instant.ofEpochMilli(0)
@@ -124,7 +138,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = time,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfEpoch = java.time.Instant.ofEpochSecond(0, 0)
@@ -165,7 +183,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = time,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC"))
@@ -206,7 +228,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = time
+      _local_timestamp_micros = time,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(0, 0), java.time.ZoneId.of("UTC"))
@@ -237,5 +263,72 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     post.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe postFormatRange
     upper.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe upperBound
     era.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEra
+  }
+
+  // Pre-epoch nanos cases are omitted: Avro 1.12's TimestampNanosConversion.toLong
+  // has a bug for negative seconds with positive nanos (subtracts 1_000_000 instead
+  // of 1_000_000_000), so round-trip is lossy below the epoch.
+  test("timestamp-nanos should work at the edges") {
+    def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = time,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
+    )
+
+    val startOfEpoch = java.time.Instant.ofEpochSecond(0L, 0L)
+    val nanoPrecision = java.time.Instant.ofEpochSecond(1234567890L, 123456789L)
+    val upperBound = java.time.Instant.ofEpochSecond(Long.MaxValue / 1_000_000_000L, Long.MaxValue % 1_000_000_000L)
+
+    val start = logicalTypes(startOfEpoch)
+    val nano = logicalTypes(nanoPrecision)
+    val upper = logicalTypes(upperBound)
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(start), start.getSchema) shouldBe start
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(nano), nano.getSchema) shouldBe nano
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
+
+    start.get(8).asInstanceOf[java.time.Instant] shouldBe startOfEpoch
+    nano.get(8).asInstanceOf[java.time.Instant] shouldBe nanoPrecision
+    upper.get(8).asInstanceOf[java.time.Instant] shouldBe upperBound
+  }
+
+  test("local-timestamp-nanos should work at the edges") {
+    def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = time,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
+    )
+
+    val startOfEpoch = java.time.LocalDateTime.ofEpochSecond(0L, 0, java.time.ZoneOffset.UTC)
+    val nanoPrecision = java.time.LocalDateTime.ofEpochSecond(1234567890L, 123456789, java.time.ZoneOffset.UTC)
+    val upperBound = java.time.LocalDateTime.ofEpochSecond(Long.MaxValue / 1_000_000_000L, (Long.MaxValue % 1_000_000_000L).toInt, java.time.ZoneOffset.UTC)
+
+    val start = logicalTypes(startOfEpoch)
+    val nano = logicalTypes(nanoPrecision)
+    val upper = logicalTypes(upperBound)
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(start), start.getSchema) shouldBe start
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(nano), nano.getSchema) shouldBe nano
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
+
+    start.get(9).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEpoch
+    nano.get(9).asInstanceOf[java.time.LocalDateTime] shouldBe nanoPrecision
+    upper.get(9).asInstanceOf[java.time.LocalDateTime] shouldBe upperBound
   }
 }

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/DecimalFixed.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/DecimalFixed.scala
@@ -15,8 +15,8 @@ case class DecimalFixed() extends org.apache.avro.specific.SpecificFixed {
 
 object DecimalFixed {
   val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"DecimalFixed","namespace":"avro2s.test.logical","size":2,"logicalType":"decimal","precision":4,"scale":2}""")
-  val READER$ = new org.apache.avro.specific.SpecificDatumReader[DecimalFixed](DecimalFixed.SCHEMA$)
-  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[DecimalFixed](DecimalFixed.SCHEMA$)
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[DecimalFixed](DecimalFixed.SCHEMA$, DecimalFixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[DecimalFixed](DecimalFixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
   def apply(data: Array[Byte]): DecimalFixed = {
     val fixed = new avro2s.test.logical.DecimalFixed()
     fixed.bytes(data)

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/DurationFixed.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/DurationFixed.scala
@@ -1,0 +1,25 @@
+/** GENERATED CODE */
+
+package avro2s.test.logical
+
+case class DurationFixed() extends org.apache.avro.specific.SpecificFixed {
+  override def getSchema: org.apache.avro.Schema = DurationFixed.SCHEMA$
+  override def readExternal(in: java.io.ObjectInput): Unit = {
+    avro2s.test.logical.DurationFixed.READER$.read(this, org.apache.avro.specific.SpecificData.getDecoder(in))
+    ()
+  }
+  override def writeExternal(out: java.io.ObjectOutput): Unit = {
+    avro2s.test.logical.DurationFixed.WRITER$.write(this, org.apache.avro.specific.SpecificData.getEncoder(out))
+  }
+}
+
+object DurationFixed {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"DurationFixed","namespace":"avro2s.test.logical","size":12,"logicalType":"duration"}""")
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[DurationFixed](DurationFixed.SCHEMA$, DurationFixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[DurationFixed](DurationFixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  def apply(data: Array[Byte]): DurationFixed = {
+    val fixed = new avro2s.test.logical.DurationFixed()
+    fixed.bytes(data)
+    fixed
+  }
+}

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalDuration.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalDuration.scala
@@ -1,0 +1,36 @@
+/** GENERATED CODE */
+
+package avro2s.test.logical
+
+import scala.annotation.switch
+
+case class LogicalDuration(var _duration: org.apache.avro.util.TimePeriod) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(org.apache.avro.util.TimePeriod.of(0L, 0L, 0L))
+
+  override def getSchema: org.apache.avro.Schema = LogicalDuration.SCHEMA$
+
+  override def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {new org.apache.avro.Conversions.DurationConversion().toFixed(_duration, avro2s.test.logical.DurationFixed.SCHEMA$, avro2s.test.logical.DurationFixed.SCHEMA$.getLogicalType)}.asInstanceOf[AnyRef]
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this._duration = {value.asInstanceOf[org.apache.avro.util.TimePeriod]}
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def getConversion(field: Int): org.apache.avro.Conversion[_] = {
+    (field: @switch) match {
+      case 0 => null
+      case _ => null
+    }
+  }
+}
+
+object LogicalDuration {
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalDuration","namespace":"avro2s.test.logical","fields":[{"name":"_duration","type":{"type":"fixed","name":"DurationFixed","size":12,"logicalType":"duration"}}]}""")
+}

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalFixedDecimal.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalFixedDecimal.scala
@@ -1,0 +1,36 @@
+/** GENERATED CODE */
+
+package avro2s.test.logical
+
+import scala.annotation.switch
+
+case class LogicalFixedDecimal(var _decimal_fixed: scala.math.BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(scala.math.BigDecimal(0))
+
+  override def getSchema: org.apache.avro.Schema = LogicalFixedDecimal.SCHEMA$
+
+  override def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {val unscaled = _decimal_fixed.setScale(2).bigDecimal.unscaledValue().toByteArray; if (unscaled.length > 2) throw new ArithmeticException("Decimal value does not fit in " + 2 + " bytes: requires " + unscaled.length + " bytes"); val padded = new Array[Byte](2); val fillByte: Byte = if (unscaled.length > 0 && unscaled(0) < 0) 0xFF.toByte else 0x00.toByte; java.util.Arrays.fill(padded, fillByte); System.arraycopy(unscaled, 0, padded, 2 - unscaled.length, unscaled.length); val result = new avro2s.test.logical.DecimalFixed(); result.bytes(padded); result}.asInstanceOf[AnyRef]
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this._decimal_fixed = {scala.math.BigDecimal(new java.math.BigDecimal(new java.math.BigInteger(value.asInstanceOf[org.apache.avro.generic.GenericFixed].bytes()), 2))}
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def getConversion(field: Int): org.apache.avro.Conversion[_] = {
+    (field: @switch) match {
+      case 0 => null
+      case _ => null
+    }
+  }
+}
+
+object LogicalFixedDecimal {
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalFixedDecimal","namespace":"avro2s.test.logical","fields":[{"name":"_decimal_fixed","type":{"type":"fixed","name":"DecimalFixed","size":2,"logicalType":"decimal","precision":4,"scale":2}}]}""")
+}

--- a/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/logical/LogicalTypes.scala
@@ -4,8 +4,8 @@ package avro2s.test.logical
 
 import scala.annotation.switch
 
-case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDate, var _time_millis: java.time.LocalTime, var _time_micros: java.time.LocalTime, var _timestamp_millis: java.time.Instant, var _timestamp_micros: java.time.Instant, var _local_timestamp_millis: java.time.LocalDateTime, var _local_timestamp_micros: java.time.LocalDateTime) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(java.util.UUID.fromString("00000000-0000-0000-0000-000000000000"), java.time.LocalDate.ofEpochDay(0), java.time.LocalTime.ofNanoOfDay(0), java.time.LocalTime.ofNanoOfDay(0), java.time.Instant.ofEpochMilli(0), java.time.Instant.ofEpochSecond(0, 0), java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC")), java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(0, 0), java.time.ZoneId.of("UTC")))
+case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDate, var _time_millis: java.time.LocalTime, var _time_micros: java.time.LocalTime, var _timestamp_millis: java.time.Instant, var _timestamp_micros: java.time.Instant, var _local_timestamp_millis: java.time.LocalDateTime, var _local_timestamp_micros: java.time.LocalDateTime, var _timestamp_nanos: java.time.Instant, var _local_timestamp_nanos: java.time.LocalDateTime, var _decimal: scala.math.BigDecimal, var _big_decimal: java.math.BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(java.util.UUID.fromString("00000000-0000-0000-0000-000000000000"), java.time.LocalDate.ofEpochDay(0), java.time.LocalTime.ofNanoOfDay(0), java.time.LocalTime.ofNanoOfDay(0), java.time.Instant.ofEpochMilli(0), java.time.Instant.ofEpochSecond(0, 0), java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC")), java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(0, 0), java.time.ZoneId.of("UTC")), java.time.Instant.ofEpochSecond(0L, 0L), java.time.LocalDateTime.ofEpochSecond(0L, 0, java.time.ZoneOffset.UTC), scala.math.BigDecimal(0), java.math.BigDecimal.ZERO)
 
   override def getSchema: org.apache.avro.Schema = LogicalTypes.SCHEMA$
 
@@ -21,6 +21,10 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
       case 5 => _timestamp_micros.asInstanceOf[AnyRef]
       case 6 => _local_timestamp_millis.asInstanceOf[AnyRef]
       case 7 => _local_timestamp_micros.asInstanceOf[AnyRef]
+      case 8 => _timestamp_nanos.asInstanceOf[AnyRef]
+      case 9 => _local_timestamp_nanos.asInstanceOf[AnyRef]
+      case 10 => {java.nio.ByteBuffer.wrap(_decimal.setScale(2).bigDecimal.unscaledValue().toByteArray)}.asInstanceOf[AnyRef]
+      case 11 => {new org.apache.avro.Conversions.BigDecimalConversion().toBytes(_big_decimal, null, null)}.asInstanceOf[AnyRef]
       case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
     }
   }
@@ -35,6 +39,14 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
       case 5 => this._timestamp_micros = value.asInstanceOf[java.time.Instant]
       case 6 => this._local_timestamp_millis = value.asInstanceOf[java.time.LocalDateTime]
       case 7 => this._local_timestamp_micros = value.asInstanceOf[java.time.LocalDateTime]
+      case 8 => this._timestamp_nanos = value.asInstanceOf[java.time.Instant]
+      case 9 => this._local_timestamp_nanos = value.asInstanceOf[java.time.LocalDateTime]
+      case 10 => this._decimal = {
+        value match {
+          case buffer: java.nio.ByteBuffer => {scala.math.BigDecimal(new java.math.BigDecimal(new java.math.BigInteger(buffer.array()), 2))}
+        }
+      }
+      case 11 => this._big_decimal = value.asInstanceOf[java.math.BigDecimal]
       case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
     }
   }
@@ -49,13 +61,17 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
       case 5 => LogicalTypes.$TimestampMicrosConversion
       case 6 => LogicalTypes.$LocalTimestampMillisConversion
       case 7 => LogicalTypes.$LocalTimestampMicrosConversion
+      case 8 => LogicalTypes.$TimestampNanosConversion
+      case 9 => LogicalTypes.$LocalTimestampNanosConversion
+      case 10 => null
+      case 11 => null
       case _ => null
     }
   }
 }
 
 object LogicalTypes {
-  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}""")
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}},{"name":"_timestamp_nanos","type":{"type":"long","logicalType":"timestamp-nanos"}},{"name":"_local_timestamp_nanos","type":{"type":"long","logicalType":"local-timestamp-nanos"}},{"name":"_decimal","type":{"type":"bytes","logicalType":"decimal","precision":10,"scale":2}},{"name":"_big_decimal","type":{"type":"bytes","logicalType":"big-decimal"}}]}""")
   val $UUIDConversion: org.apache.avro.Conversion[_] = new org.apache.avro.Conversions.UUIDConversion()
   val $DateConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.DateConversion()
   val $TimeMillisConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()
@@ -64,6 +80,8 @@ object LogicalTypes {
   val $TimestampMicrosConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
   val $LocalTimestampMillisConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
   val $LocalTimestampMicrosConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
+  val $TimestampNanosConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.TimestampNanosConversion()
+  val $LocalTimestampNanosConversion: org.apache.avro.Conversion[_] = new org.apache.avro.data.TimeConversions.LocalTimestampNanosConversion()
   val MODEL$: org.apache.avro.specific.SpecificData = {
     val model = new org.apache.avro.specific.SpecificData()
     model.addLogicalTypeConversion($UUIDConversion)
@@ -74,6 +92,8 @@ object LogicalTypes {
     model.addLogicalTypeConversion($TimestampMicrosConversion)
     model.addLogicalTypeConversion($LocalTimestampMillisConversion)
     model.addLogicalTypeConversion($LocalTimestampMicrosConversion)
+    model.addLogicalTypeConversion($TimestampNanosConversion)
+    model.addLogicalTypeConversion($LocalTimestampNanosConversion)
     model
   }
 }

--- a/avro2s/src/test/scala-3/avro2s/generator/CodeGeneratorTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/CodeGeneratorTest.scala
@@ -181,6 +181,24 @@ class CodeGeneratorTest extends AnyFunSuite with Matchers {
     tripleQuotedSegments.foreach(seg => seg.length should be <= 65000)
   }
 
+  test("logical fixed decimal types should produce expected output") {
+    val code = generateCode("input/logical-enabled/logical/logical-fixed-decimal.avsc", logicalTypesEnabled = true)
+
+    code.foreach { code =>
+      val expectedCode = loadTestCode("logical", code.path.split("/").last)
+      testResult(code, expectedCode)
+    }
+  }
+
+  test("logical duration types should produce expected output") {
+    val code = generateCode("input/logical-enabled/logical/logical-duration.avsc", logicalTypesEnabled = true)
+
+    code.foreach { code =>
+      val expectedCode = loadTestCode("logical", code.path.split("/").last)
+      testResult(code, expectedCode)
+    }
+  }
+
   def generateCode(path: String, logicalTypesEnabled: Boolean = false): List[GeneratedCode] = {
     val generatorConfig = GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled)
 

--- a/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
@@ -262,10 +262,42 @@ class SerializationTest extends AnyFunSuite with Matchers {
       _timestamp_millis = java.time.Instant.ofEpochMilli(1234567890123L),
       _timestamp_micros = java.time.Instant.ofEpochSecond(1234567890L, 123456000L),
       _local_timestamp_millis = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(1234567890123L), java.time.ZoneOffset.UTC),
-      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(1234567890L, 123456000L), java.time.ZoneOffset.UTC)
+      _local_timestamp_micros = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(1234567890L, 123456000L), java.time.ZoneOffset.UTC),
+      _timestamp_nanos = java.time.Instant.ofEpochSecond(1234567890L, 123456789L),
+      _local_timestamp_nanos = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(1234567890L, 123456789L), java.time.ZoneOffset.UTC),
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     deserialize[avro2s.test.logical.LogicalTypes](serialize(logicalTypes), logicalTypes.getSchema) shouldBe logicalTypes
+  }
+
+  test("logical fixed decimal can be serialized and deserialized") {
+    val logicalFixedDecimal = avro2s.test.logical.LogicalFixedDecimal(
+      _decimal_fixed = scala.math.BigDecimal("12.34")
+    )
+    deserialize[avro2s.test.logical.LogicalFixedDecimal](serialize(logicalFixedDecimal), logicalFixedDecimal.getSchema) shouldBe logicalFixedDecimal
+  }
+
+  test("logical fixed decimal handles negative values via sign extension") {
+    val negative = avro2s.test.logical.LogicalFixedDecimal(
+      _decimal_fixed = scala.math.BigDecimal("-12.34")
+    )
+    deserialize[avro2s.test.logical.LogicalFixedDecimal](serialize(negative), negative.getSchema) shouldBe negative
+  }
+
+  test("logical fixed decimal rejects values that do not fit in the fixed size") {
+    val tooLarge = avro2s.test.logical.LogicalFixedDecimal(
+      _decimal_fixed = scala.math.BigDecimal("99999.99")
+    )
+    an[ArithmeticException] should be thrownBy serialize(tooLarge)
+  }
+
+  test("logical duration can be serialized and deserialized") {
+    val logicalDuration = avro2s.test.logical.LogicalDuration(
+      _duration = org.apache.avro.util.TimePeriod.of(1L, 2L, 3L)
+    )
+    deserialize[avro2s.test.logical.LogicalDuration](serialize(logicalDuration), logicalDuration.getSchema) shouldBe logicalDuration
   }
 
   test("logical types disabled can be serialized and deserialized") {

--- a/avro2s/src/test/scala-3/avro2s/generator/logical/LogicalTypesTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/logical/LogicalTypesTest.scala
@@ -17,6 +17,8 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
   private val fixedTimestampMicros = java.time.Instant.ofEpochSecond(1234567890L, 123456000L)
   private val fixedLocalTimestampMillis = java.time.LocalDateTime.ofInstant(fixedTimestampMillis, java.time.ZoneOffset.UTC)
   private val fixedLocalTimestampMicros = java.time.LocalDateTime.ofInstant(fixedTimestampMicros, java.time.ZoneOffset.UTC)
+  private val fixedTimestampNanos = java.time.Instant.ofEpochSecond(1234567890L, 123456789L)
+  private val fixedLocalTimestampNanos = java.time.LocalDateTime.ofInstant(fixedTimestampNanos, java.time.ZoneOffset.UTC)
 
   test("time-millis should work at the edges") {
     def logicalTypes(time: java.time.LocalTime) = avro2s.test.logical.LogicalTypes(
@@ -27,7 +29,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
@@ -55,7 +61,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfDay = java.time.LocalTime.ofNanoOfDay(0)
@@ -83,7 +93,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = time,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfEpoch = java.time.Instant.ofEpochMilli(0)
@@ -124,7 +138,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = time,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfEpoch = java.time.Instant.ofEpochSecond(0, 0)
@@ -165,7 +183,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = time,
-      _local_timestamp_micros = fixedLocalTimestampMicros
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC"))
@@ -206,7 +228,11 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
       _timestamp_millis = fixedTimestampMillis,
       _timestamp_micros = fixedTimestampMicros,
       _local_timestamp_millis = fixedLocalTimestampMillis,
-      _local_timestamp_micros = time
+      _local_timestamp_micros = time,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
     )
 
     val startOfEpoch = java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(0, 0), java.time.ZoneId.of("UTC"))
@@ -237,5 +263,72 @@ class LogicalTypesTest extends AnyFunSuite with Matchers {
     post.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe postFormatRange
     upper.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe upperBound
     era.get(7).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEra
+  }
+
+  // Pre-epoch nanos cases are omitted: Avro 1.12's TimestampNanosConversion.toLong
+  // has a bug for negative seconds with positive nanos (subtracts 1_000_000 instead
+  // of 1_000_000_000), so round-trip is lossy below the epoch.
+  test("timestamp-nanos should work at the edges") {
+    def logicalTypes(time: java.time.Instant) = avro2s.test.logical.LogicalTypes(
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = time,
+      _local_timestamp_nanos = fixedLocalTimestampNanos,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
+    )
+
+    val startOfEpoch = java.time.Instant.ofEpochSecond(0L, 0L)
+    val nanoPrecision = java.time.Instant.ofEpochSecond(1234567890L, 123456789L)
+    val upperBound = java.time.Instant.ofEpochSecond(Long.MaxValue / 1_000_000_000L, Long.MaxValue % 1_000_000_000L)
+
+    val start = logicalTypes(startOfEpoch)
+    val nano = logicalTypes(nanoPrecision)
+    val upper = logicalTypes(upperBound)
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(start), start.getSchema) shouldBe start
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(nano), nano.getSchema) shouldBe nano
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
+
+    start.get(8).asInstanceOf[java.time.Instant] shouldBe startOfEpoch
+    nano.get(8).asInstanceOf[java.time.Instant] shouldBe nanoPrecision
+    upper.get(8).asInstanceOf[java.time.Instant] shouldBe upperBound
+  }
+
+  test("local-timestamp-nanos should work at the edges") {
+    def logicalTypes(time: java.time.LocalDateTime) = avro2s.test.logical.LogicalTypes(
+      _uuid = fixedUuid,
+      _date = fixedDate,
+      _time_millis = fixedTimeMillis,
+      _time_micros = fixedTimeMicros,
+      _timestamp_millis = fixedTimestampMillis,
+      _timestamp_micros = fixedTimestampMicros,
+      _local_timestamp_millis = fixedLocalTimestampMillis,
+      _local_timestamp_micros = fixedLocalTimestampMicros,
+      _timestamp_nanos = fixedTimestampNanos,
+      _local_timestamp_nanos = time,
+      _decimal = scala.math.BigDecimal("12345.67"),
+      _big_decimal = new java.math.BigDecimal("12345.67")
+    )
+
+    val startOfEpoch = java.time.LocalDateTime.ofEpochSecond(0L, 0, java.time.ZoneOffset.UTC)
+    val nanoPrecision = java.time.LocalDateTime.ofEpochSecond(1234567890L, 123456789, java.time.ZoneOffset.UTC)
+    val upperBound = java.time.LocalDateTime.ofEpochSecond(Long.MaxValue / 1_000_000_000L, (Long.MaxValue % 1_000_000_000L).toInt, java.time.ZoneOffset.UTC)
+
+    val start = logicalTypes(startOfEpoch)
+    val nano = logicalTypes(nanoPrecision)
+    val upper = logicalTypes(upperBound)
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(start), start.getSchema) shouldBe start
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(nano), nano.getSchema) shouldBe nano
+    deserialize[avro2s.test.logical.LogicalTypes](serialize(upper), upper.getSchema) shouldBe upper
+
+    start.get(9).asInstanceOf[java.time.LocalDateTime] shouldBe startOfEpoch
+    nano.get(9).asInstanceOf[java.time.LocalDateTime] shouldBe nanoPrecision
+    upper.get(9).asInstanceOf[java.time.LocalDateTime] shouldBe upperBound
   }
 }

--- a/avro2s/src/test/scala-3/avro2s/test/logical/DecimalFixed.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/DecimalFixed.scala
@@ -1,0 +1,25 @@
+/** GENERATED CODE */
+
+package avro2s.test.logical
+
+case class DecimalFixed() extends org.apache.avro.specific.SpecificFixed {
+  override def getSchema: org.apache.avro.Schema = DecimalFixed.SCHEMA$
+  override def readExternal(in: java.io.ObjectInput): Unit = {
+    avro2s.test.logical.DecimalFixed.READER$.read(this, org.apache.avro.specific.SpecificData.getDecoder(in))
+    ()
+  }
+  override def writeExternal(out: java.io.ObjectOutput): Unit = {
+    avro2s.test.logical.DecimalFixed.WRITER$.write(this, org.apache.avro.specific.SpecificData.getEncoder(out))
+  }
+}
+
+object DecimalFixed {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"DecimalFixed","namespace":"avro2s.test.logical","size":2,"logicalType":"decimal","precision":4,"scale":2}""")
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[DecimalFixed](DecimalFixed.SCHEMA$, DecimalFixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[DecimalFixed](DecimalFixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  def apply(data: Array[Byte]): DecimalFixed = {
+    val fixed = new avro2s.test.logical.DecimalFixed()
+    fixed.bytes(data)
+    fixed
+  }
+}

--- a/avro2s/src/test/scala-3/avro2s/test/logical/DurationFixed.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/DurationFixed.scala
@@ -1,0 +1,25 @@
+/** GENERATED CODE */
+
+package avro2s.test.logical
+
+case class DurationFixed() extends org.apache.avro.specific.SpecificFixed {
+  override def getSchema: org.apache.avro.Schema = DurationFixed.SCHEMA$
+  override def readExternal(in: java.io.ObjectInput): Unit = {
+    avro2s.test.logical.DurationFixed.READER$.read(this, org.apache.avro.specific.SpecificData.getDecoder(in))
+    ()
+  }
+  override def writeExternal(out: java.io.ObjectOutput): Unit = {
+    avro2s.test.logical.DurationFixed.WRITER$.write(this, org.apache.avro.specific.SpecificData.getEncoder(out))
+  }
+}
+
+object DurationFixed {
+  val SCHEMA$ = new org.apache.avro.Schema.Parser().parse("""{"type":"fixed","name":"DurationFixed","namespace":"avro2s.test.logical","size":12,"logicalType":"duration"}""")
+  val READER$ = new org.apache.avro.specific.SpecificDatumReader[DurationFixed](DurationFixed.SCHEMA$, DurationFixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  val WRITER$ = new org.apache.avro.specific.SpecificDatumWriter[DurationFixed](DurationFixed.SCHEMA$, new org.apache.avro.specific.SpecificData())
+  def apply(data: Array[Byte]): DurationFixed = {
+    val fixed = new avro2s.test.logical.DurationFixed()
+    fixed.bytes(data)
+    fixed
+  }
+}

--- a/avro2s/src/test/scala-3/avro2s/test/logical/LogicalDuration.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/LogicalDuration.scala
@@ -1,0 +1,38 @@
+/** GENERATED CODE */
+
+package avro2s.test.logical
+
+import scala.annotation.switch
+
+case class LogicalDuration(var _duration: org.apache.avro.util.TimePeriod) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(org.apache.avro.util.TimePeriod.of(0L, 0L, 0L))
+
+  override def getSchema: org.apache.avro.Schema = LogicalDuration.SCHEMA$
+
+  override def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {new org.apache.avro.Conversions.DurationConversion().toFixed(_duration, avro2s.test.logical.DurationFixed.SCHEMA$, avro2s.test.logical.DurationFixed.SCHEMA$.getLogicalType)}.asInstanceOf[AnyRef]
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this._duration = {
+        {value.asInstanceOf[org.apache.avro.util.TimePeriod]}
+      }
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def getConversion(field: Int): org.apache.avro.Conversion[?] = {
+    (field: @switch) match {
+      case 0 => null
+      case _ => null
+    }
+  }
+}
+
+object LogicalDuration {
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalDuration","namespace":"avro2s.test.logical","fields":[{"name":"_duration","type":{"type":"fixed","name":"DurationFixed","size":12,"logicalType":"duration"}}]}""")
+}

--- a/avro2s/src/test/scala-3/avro2s/test/logical/LogicalFixedDecimal.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/LogicalFixedDecimal.scala
@@ -1,0 +1,38 @@
+/** GENERATED CODE */
+
+package avro2s.test.logical
+
+import scala.annotation.switch
+
+case class LogicalFixedDecimal(var _decimal_fixed: scala.math.BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(scala.math.BigDecimal(0))
+
+  override def getSchema: org.apache.avro.Schema = LogicalFixedDecimal.SCHEMA$
+
+  override def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => {val unscaled = _decimal_fixed.setScale(2).bigDecimal.unscaledValue().toByteArray; if (unscaled.length > 2) throw new ArithmeticException("Decimal value does not fit in " + 2 + " bytes: requires " + unscaled.length + " bytes"); val padded = new Array[Byte](2); val fillByte: Byte = if (unscaled.length > 0 && unscaled(0) < 0) 0xFF.toByte else 0x00.toByte; java.util.Arrays.fill(padded, fillByte); System.arraycopy(unscaled, 0, padded, 2 - unscaled.length, unscaled.length); val result = new avro2s.test.logical.DecimalFixed(); result.bytes(padded); result}.asInstanceOf[AnyRef]
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this._decimal_fixed = {
+        {scala.math.BigDecimal(new java.math.BigDecimal(new java.math.BigInteger(value.asInstanceOf[org.apache.avro.generic.GenericFixed].bytes()), 2))}
+      }
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def getConversion(field: Int): org.apache.avro.Conversion[?] = {
+    (field: @switch) match {
+      case 0 => null
+      case _ => null
+    }
+  }
+}
+
+object LogicalFixedDecimal {
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalFixedDecimal","namespace":"avro2s.test.logical","fields":[{"name":"_decimal_fixed","type":{"type":"fixed","name":"DecimalFixed","size":2,"logicalType":"decimal","precision":4,"scale":2}}]}""")
+}

--- a/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/logical/LogicalTypes.scala
@@ -4,8 +4,8 @@ package avro2s.test.logical
 
 import scala.annotation.switch
 
-case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDate, var _time_millis: java.time.LocalTime, var _time_micros: java.time.LocalTime, var _timestamp_millis: java.time.Instant, var _timestamp_micros: java.time.Instant, var _local_timestamp_millis: java.time.LocalDateTime, var _local_timestamp_micros: java.time.LocalDateTime) extends org.apache.avro.specific.SpecificRecordBase {
-  def this() = this(java.util.UUID.fromString("00000000-0000-0000-0000-000000000000"), java.time.LocalDate.ofEpochDay(0), java.time.LocalTime.ofNanoOfDay(0), java.time.LocalTime.ofNanoOfDay(0), java.time.Instant.ofEpochMilli(0), java.time.Instant.ofEpochSecond(0, 0), java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC")), java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(0, 0), java.time.ZoneId.of("UTC")))
+case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDate, var _time_millis: java.time.LocalTime, var _time_micros: java.time.LocalTime, var _timestamp_millis: java.time.Instant, var _timestamp_micros: java.time.Instant, var _local_timestamp_millis: java.time.LocalDateTime, var _local_timestamp_micros: java.time.LocalDateTime, var _timestamp_nanos: java.time.Instant, var _local_timestamp_nanos: java.time.LocalDateTime, var _decimal: scala.math.BigDecimal, var _big_decimal: java.math.BigDecimal) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(java.util.UUID.fromString("00000000-0000-0000-0000-000000000000"), java.time.LocalDate.ofEpochDay(0), java.time.LocalTime.ofNanoOfDay(0), java.time.LocalTime.ofNanoOfDay(0), java.time.Instant.ofEpochMilli(0), java.time.Instant.ofEpochSecond(0, 0), java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochMilli(0), java.time.ZoneId.of("UTC")), java.time.LocalDateTime.ofInstant(java.time.Instant.ofEpochSecond(0, 0), java.time.ZoneId.of("UTC")), java.time.Instant.ofEpochSecond(0L, 0L), java.time.LocalDateTime.ofEpochSecond(0L, 0, java.time.ZoneOffset.UTC), scala.math.BigDecimal(0), java.math.BigDecimal.ZERO)
 
   override def getSchema: org.apache.avro.Schema = LogicalTypes.SCHEMA$
 
@@ -21,6 +21,10 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
       case 5 => _timestamp_micros.asInstanceOf[AnyRef]
       case 6 => _local_timestamp_millis.asInstanceOf[AnyRef]
       case 7 => _local_timestamp_micros.asInstanceOf[AnyRef]
+      case 8 => _timestamp_nanos.asInstanceOf[AnyRef]
+      case 9 => _local_timestamp_nanos.asInstanceOf[AnyRef]
+      case 10 => {java.nio.ByteBuffer.wrap(_decimal.setScale(2).bigDecimal.unscaledValue().toByteArray)}.asInstanceOf[AnyRef]
+      case 11 => {new org.apache.avro.Conversions.BigDecimalConversion().toBytes(_big_decimal, null, null)}.asInstanceOf[AnyRef]
       case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
     }
   }
@@ -51,6 +55,19 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
       case 7 => this._local_timestamp_micros = {
         value.asInstanceOf[java.time.LocalDateTime]
       }
+      case 8 => this._timestamp_nanos = {
+        value.asInstanceOf[java.time.Instant]
+      }
+      case 9 => this._local_timestamp_nanos = {
+        value.asInstanceOf[java.time.LocalDateTime]
+      }
+      case 10 => this._decimal = {
+        val buffer = value.asInstanceOf[java.nio.ByteBuffer]
+        {scala.math.BigDecimal(new java.math.BigDecimal(new java.math.BigInteger(buffer.array()), 2))}
+      }
+      case 11 => this._big_decimal = {
+        value.asInstanceOf[java.math.BigDecimal]
+      }
       case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
     }
   }
@@ -65,13 +82,17 @@ case class LogicalTypes(var _uuid: java.util.UUID, var _date: java.time.LocalDat
       case 5 => LogicalTypes.$TimestampMicrosConversion
       case 6 => LogicalTypes.$LocalTimestampMillisConversion
       case 7 => LogicalTypes.$LocalTimestampMicrosConversion
+      case 8 => LogicalTypes.$TimestampNanosConversion
+      case 9 => LogicalTypes.$LocalTimestampNanosConversion
+      case 10 => null
+      case 11 => null
       case _ => null
     }
   }
 }
 
 object LogicalTypes {
-  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}}]}""")
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"LogicalTypes","namespace":"avro2s.test.logical","fields":[{"name":"_uuid","type":{"type":"string","logicalType":"uuid"}},{"name":"_date","type":{"type":"int","logicalType":"date"}},{"name":"_time_millis","type":{"type":"int","logicalType":"time-millis"}},{"name":"_time_micros","type":{"type":"long","logicalType":"time-micros"}},{"name":"_timestamp_millis","type":{"type":"long","logicalType":"timestamp-millis"}},{"name":"_timestamp_micros","type":{"type":"long","logicalType":"timestamp-micros"}},{"name":"_local_timestamp_millis","type":{"type":"long","logicalType":"local-timestamp-millis"}},{"name":"_local_timestamp_micros","type":{"type":"long","logicalType":"local-timestamp-micros"}},{"name":"_timestamp_nanos","type":{"type":"long","logicalType":"timestamp-nanos"}},{"name":"_local_timestamp_nanos","type":{"type":"long","logicalType":"local-timestamp-nanos"}},{"name":"_decimal","type":{"type":"bytes","logicalType":"decimal","precision":10,"scale":2}},{"name":"_big_decimal","type":{"type":"bytes","logicalType":"big-decimal"}}]}""")
   val $UUIDConversion: org.apache.avro.Conversion[?] = new org.apache.avro.Conversions.UUIDConversion()
   val $DateConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.DateConversion()
   val $TimeMillisConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimeMillisConversion()
@@ -80,6 +101,8 @@ object LogicalTypes {
   val $TimestampMicrosConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimestampMicrosConversion()
   val $LocalTimestampMillisConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.LocalTimestampMillisConversion()
   val $LocalTimestampMicrosConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.LocalTimestampMicrosConversion()
+  val $TimestampNanosConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.TimestampNanosConversion()
+  val $LocalTimestampNanosConversion: org.apache.avro.Conversion[?] = new org.apache.avro.data.TimeConversions.LocalTimestampNanosConversion()
   val MODEL$: org.apache.avro.specific.SpecificData = {
     val model = new org.apache.avro.specific.SpecificData()
     model.addLogicalTypeConversion($UUIDConversion)
@@ -90,6 +113,8 @@ object LogicalTypes {
     model.addLogicalTypeConversion($TimestampMicrosConversion)
     model.addLogicalTypeConversion($LocalTimestampMillisConversion)
     model.addLogicalTypeConversion($LocalTimestampMicrosConversion)
+    model.addLogicalTypeConversion($TimestampNanosConversion)
+    model.addLogicalTypeConversion($LocalTimestampNanosConversion)
     model
   }
 }


### PR DESCRIPTION
## Summary

Four new logical types added as a single squashed commit:

- **`timestamp-nanos` / `local-timestamp-nanos`** — nanosecond-precision timestamp types from Avro 1.12, following the existing micros pattern. Edge tests cover epoch, full-nanosecond precision, and `Long.MaxValue`. Pre-epoch values are intentionally omitted because Avro 1.12's `TimestampNanosConversion.toLong` subtracts `1_000_000` instead of `1_000_000_000` for negative seconds with positive nanos.
- **`decimal`** — implements the previously-stubbed `Decimal` case object for both `BYTES` and `FIXED` backings; Scala type `scala.math.BigDecimal`. `BYTES` uses `Conversions.DecimalConversion`; `FIXED` generates sign-extended byte serialisation in `get()` with a length check that throws `ArithmeticException` when the unscaled value exceeds the fixed size, and `GenericFixed`-aware deserialisation in `put()`.
- **`duration`** — Scala type `org.apache.avro.util.TimePeriod` (Avro 1.12 auto-applies `DurationConversion` on read); `get()` invokes `DurationConversion.toFixed` manually so writes use the registered codec.
- **`big-decimal`** — new Avro 1.12 logical type backed by `BYTES`; Scala type `java.math.BigDecimal`. Avro's reader auto-applies `BigDecimalConversion` before calling `put()`, so `put()` does a direct cast; `get()` serialises manually via `BigDecimalConversion.toBytes`.

## Test plan
- [x] `sbt +test` passes across Scala 2.12.20, 2.13.16, 3.3.6 (56 tests, 7 pre-existing ignores unchanged)
- [x] Round-trip coverage in `SerializationTest` for every new type, including positive/negative/over-capacity `FIXED`-decimal and `LogicalDuration`
- [x] Edge tests in `LogicalTypesTest` for `timestamp-nanos` / `local-timestamp-nanos`
- [x] `CodeGeneratorTest` snapshots updated for `logical-fixed-decimal.avsc` and the new `logical-duration.avsc`