### PR TITLE
fix: ScalaVersion.fromString correctly distinguishes invalid vs unsupported

### DIFF
--- a/avro2s/src/main/scala/avro2s/language/ScalaVersion.scala
+++ b/avro2s/src/main/scala/avro2s/language/ScalaVersion.scala
@@ -7,13 +7,13 @@ sealed abstract class ScalaVersion(val asString: String)
 object ScalaVersion {
   case object Scala_2_13 extends ScalaVersion("2.13")
   case object Scala_3 extends ScalaVersion("3")
-  
+
   private val pattern = """^\d+\.\d+$"""
   def fromString(s: String): ScalaVersion = s match {
     case "2.13" => Scala_2_13
     case "3" | "3.X" | "3.x" => Scala_3
     case _ if s.startsWith("3.") && s.matches(pattern) => Scala_3
-    case _ if !pattern.matches(s) => throw ConfigError(s"Invalid Scala version: $s")
+    case _ if !s.matches(pattern) => throw ConfigError(s"Invalid Scala version: $s")
     case _ => throw ConfigError(s"Unsupported Scala version: $s")
-  } 
+  }
 }

--- a/avro2s/src/test/scala/avro2s/language/ScalaVersionTest.scala
+++ b/avro2s/src/test/scala/avro2s/language/ScalaVersionTest.scala
@@ -8,7 +8,7 @@ class ScalaVersionTest extends AnyFunSuite with Matchers {
   test("fromString should return Scala_2_13 when given 2.13") {
     ScalaVersion.fromString("2.13") shouldBe ScalaVersion.Scala_2_13
   }
-  
+
   test("fromString should return Scala_3_X when given 3.X") {
     ScalaVersion.fromString("3.X") shouldBe ScalaVersion.Scala_3
     ScalaVersion.fromString("3.x") shouldBe ScalaVersion.Scala_3
@@ -17,11 +17,18 @@ class ScalaVersionTest extends AnyFunSuite with Matchers {
     ScalaVersion.fromString("3.2") shouldBe ScalaVersion.Scala_3
     ScalaVersion.fromString("3.3") shouldBe ScalaVersion.Scala_3
   }
-  
+
   test("fromString should throw ConfigError when given an invalid Scala version") {
+    val thrown = intercept[avro2s.error.Error.ConfigError] {
+      ScalaVersion.fromString("invalid")
+    }
+    thrown.getMessage shouldBe "Invalid Scala version: invalid"
+  }
+
+  test("fromString should throw ConfigError when given an unsupported Scala version") {
     val thrown = intercept[avro2s.error.Error.ConfigError] {
       ScalaVersion.fromString("2.14")
     }
-    thrown.getMessage shouldBe "Invalid Scala version: 2.14"
+    thrown.getMessage shouldBe "Unsupported Scala version: 2.14"
   }
 }


### PR DESCRIPTION
## Summary

Fixes a typo-style bug in `ScalaVersion.fromString` where `String#matches` is called with the arguments swapped:

```scala
private val pattern = """^\d+\.\d+$"""
// ...
case _ if !pattern.matches(s) => throw ConfigError(s"Invalid Scala version: $s")
```

`String#matches` is `<input>.matches(<regex>)`, so the call here treats the constant `pattern` as the input and the user-supplied `s` as the regex — backwards. Two lines above, the same function gets it right (`s.matches(pattern)`), so this looks like a copy-paste slip.

Easy mistake because Scala's [`scala.util.matching.Regex#matches`](https://www.scala-lang.org/api/2.13.x/scala/util/matching/Regex.html) has the opposite convention (`regex.matches(input)`) — but `pattern` here is a `String`, so Java's [`String#matches`](https://docs.oracle.com/javase/8/docs/api/java/lang/String.html#matches-java.lang.String-) applies.

## Example

For input `"2.14"` (a well-formed Scala version, but not one we support):

| | Before | After |
| --- | --- | --- |
| Throws | `"Invalid Scala version: 2.14"` | `"Unsupported Scala version: 2.14"` |

`"2.14"` is the correct shape (`digits.digits`), so the error should be "Unsupported", not "Invalid".

## Test changes

- Added a test exercising the "Invalid" branch with input `"invalid"`.
- Reclassified the existing `"2.14"` test to assert "Unsupported" — it always was unsupported; the inverted match was just hiding it.

## Test plan

- [x] `sbt 'testOnly avro2s.language.ScalaVersionTest'` passes