### PR TITLE
Add Scala enum support with direct-dispatch SpecificData bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Avro2s is essentially a rewrite of [avrohugger](https://github.com/julianpeeters
 #### Features:
  - Supports Scala 3
    - Union types are supported without the need for shapeless
-   - Currently, Enums are still generated as Java enums
  - Supports Scala 2.13
  - Compatibility with all Avro types
  - SBT plugin
+ - Optional idiomatic Scala enum generation (Scala 2.13 sealed ADT or Scala 3 native `enum`)
 
 #### SBT Plugin Usage
 
@@ -59,14 +59,39 @@ object Demo extends App {
   CodeGenerator.generateCode(
     "input_directory",
     "output_directory",
-    GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled = true)
+    GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled = true, enumType = None)
   )
 }  
 ```
 
+#### Scala enums (optional)
+
+By default avro2s generates Java `enum` types for Avro enum schemas. To generate idiomatic Scala enums instead, set `avro2sEnumType` in your `build.sbt`:
+
+```scala
+// Scala 2.13 — sealed abstract class with case objects:
+avro2sEnumType := Some(avro2s.generator.EnumType.ScalaADT)
+
+// Scala 3 — native enum:
+avro2sEnumType := Some(avro2s.generator.EnumType.Scala3Enum)
+```
+
+When set, avro2s additionally emits an `avro2s.generated.ScalaSpecificData` class. Each generated record that contains an enum field (or logical-type conversions) gets a `MODEL$` value in its companion object and overrides `getSpecificData` to return it. `ScalaSpecificData.createEnum` dispatches to each generated enum's companion `fromString` via a closed pattern match — no reflection.
+
+Wire format is unchanged. Java and Scala consumers of the same schema can interoperate.
+
+**Deserialization note:** Avro's `SpecificDatumReader(schema)` uses the default `SpecificData` instance, which does not know about your Scala enums. When using Scala enums, construct your reader with the record's `MODEL$` explicitly:
+
+```scala
+import org.apache.avro.specific.SpecificDatumReader
+
+val reader = new SpecificDatumReader[MyRecord](
+  MyRecord.SCHEMA$, MyRecord.SCHEMA$, MyRecord.MODEL$
+)
+```
+
 #### Roadmap:
  - Scaladoc generation
- - Scala 3 Enum support
 
 #### Acknowledgments:
  - Thank you to everyone who contributed to [avrohugger](https://github.com/julianpeeters/avrohugger), upon which this code is based.

--- a/avro2s/src/main/scala/avro2s/generator/CodeGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/CodeGenerator.scala
@@ -2,10 +2,10 @@ package avro2s.generator
 
 import avro2s.filehelper.FileHelper
 import avro2s.filesorter.AvscFileSorter
-import avro2s.generator.specific.SpecificGenerator
-import avro2s.language.ScalaVersion
+import avro2s.generator.specific.{ScalaSpecificDataGenerator, SpecificGenerator}
 import avro2s.schema.{NestedSchemaExtractor, SchemaInspector, SchemaStore}
 import org.apache.avro.Schema
+import org.apache.avro.Schema.Type.ENUM
 
 import java.io.File
 
@@ -28,8 +28,18 @@ object CodeGenerator {
     generatorConfig: GeneratorConfig
   ): List[GeneratedCode] = {
     val schemaStore = new SchemaStore
-    schemas.flatMap { schema =>
+    val perSchema = schemas.flatMap { schema =>
       generateCode(schema, schemaStore, generatorConfig)
+    }
+
+    if (generatorConfig.enumType.isEmpty) perSchema
+    else {
+      val enumSchemas = collectEnumSchemas(schemas)
+      if (enumSchemas.isEmpty) perSchema
+      else {
+        val raw = ScalaSpecificDataGenerator.generate(enumSchemas)
+        perSchema :+ raw.copy(code = trimTrailingSpaces(raw.code))
+      }
     }
   }
 
@@ -37,7 +47,7 @@ object CodeGenerator {
     schema: Schema,
     schemaStore: SchemaStore,
     generatorConfig: GeneratorConfig): List[GeneratedCode] = {
-    
+
     val generator = new SpecificGenerator(generatorConfig)
 
     val topNS: Option[String] = SchemaInspector.getNamespace(schema)
@@ -48,6 +58,13 @@ object CodeGenerator {
       val ns = SchemaInspector.getNamespace(schema) orElse topNS
       generator.compile(schema, ns)
     }).map(gc => gc.copy(code = trimTrailingSpaces(gc.code)))
+  }
+
+  private def collectEnumSchemas(schemas: List[Schema]): List[Schema] = {
+    val store = new SchemaStore
+    schemas.flatMap { schema =>
+      NestedSchemaExtractor.getNestedSchemas(schema, store)
+    }.distinct.filter(_.getType == ENUM)
   }
 
   private def trimTrailingSpaces(s: String): String = s.split("\n").map(_.replaceAll("\\s*$", "")).mkString("\n")

--- a/avro2s/src/main/scala/avro2s/generator/EnumType.scala
+++ b/avro2s/src/main/scala/avro2s/generator/EnumType.scala
@@ -1,0 +1,8 @@
+package avro2s.generator
+
+sealed trait EnumType
+
+object EnumType {
+  case object ScalaADT extends EnumType
+  case object Scala3Enum extends EnumType
+}

--- a/avro2s/src/main/scala/avro2s/generator/GeneratorConfig.scala
+++ b/avro2s/src/main/scala/avro2s/generator/GeneratorConfig.scala
@@ -5,4 +5,5 @@ import avro2s.language.ScalaVersion
 case class GeneratorConfig(
   targetScalaVersion: ScalaVersion,
   logicalTypesEnabled: Boolean,
+  enumType: Option[EnumType]
 )

--- a/avro2s/src/main/scala/avro2s/generator/generic/scala2/enumeration/GenericEnumGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/generic/scala2/enumeration/GenericEnumGenerator.scala
@@ -1,0 +1,55 @@
+package avro2s.generator.generic.scala2.enumeration
+
+import avro2s.generator.{FunctionalPrinter, GeneratedCode}
+import org.apache.commons.text.StringEscapeUtils
+
+import scala.jdk.CollectionConverters._
+
+private[avro2s] object GenericEnumGenerator {
+  def schemaToScala2Enum(schema: org.apache.avro.Schema, namespace: Option[String]): GeneratedCode = {
+    val name = schema.getName
+    val enumSymbols = schema.getEnumSymbols.asScala
+    val ns = Option(schema.getNamespace).orElse(namespace)
+    val nsString = ns.getOrElse("")
+
+    val printer = new FunctionalPrinter()
+
+    val code = printer
+      .add("/** GENERATED CODE */")
+      .newline
+      .when(ns.isDefined)(_.add(s"package $nsString").newline)
+      .newline
+      .add(s"sealed abstract class $name(val value: String, val ordinal: Int) extends org.apache.avro.generic.GenericEnumSymbol[$name] {")
+      .indent
+      .add(s"override def getSchema: org.apache.avro.Schema = $name.SCHEMA$$")
+      .add(s"override def compareTo(that: $name): Int = this.ordinal.compareTo(that.ordinal)")
+      .outdent
+      .add("}")
+      .newline
+      .add(s"object $name {")
+      .indent
+      .print(enumSymbols.zipWithIndex) { (p, symbolWithIndex) =>
+        val (symbol, index) = symbolWithIndex
+        p.add(s"""case object $symbol extends $name("$symbol", $index)""")
+      }
+      .newline
+      .add(s"""val SCHEMA$$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"${StringEscapeUtils.escapeJava(schema.toString)}\")""")
+      .newline
+      .add(s"def fromString(value: String): $name = value match {")
+      .indent
+      .print(enumSymbols) { (p, symbol) =>
+        p.add(s"""case "$symbol" => $symbol""")
+      }
+      .add(s"""case other => throw new IllegalArgumentException(s"Unknown enum value: $$other")""")
+      .outdent
+      .add("}")
+      .newline
+      .add(s"def valueOf(value: String): $name = fromString(value)")
+      .newline
+      .add(s"val values: Seq[$name] = Seq(${enumSymbols.mkString(", ")})")
+      .outdent
+      .add("}")
+
+    GeneratedCode(s"${ns.map(_.replace(".", "/") + "/").getOrElse("")}$name.scala", code.result())
+  }
+}

--- a/avro2s/src/main/scala/avro2s/generator/generic/scala3/enumeration/GenericEnumGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/generic/scala3/enumeration/GenericEnumGenerator.scala
@@ -1,0 +1,41 @@
+package avro2s.generator.generic.scala3.enumeration
+
+import avro2s.generator.{FunctionalPrinter, GeneratedCode}
+import org.apache.commons.text.StringEscapeUtils
+
+import scala.jdk.CollectionConverters._
+
+private[avro2s] object GenericEnumGenerator {
+  def schemaToScala3Enum(schema: org.apache.avro.Schema, namespace: Option[String]): GeneratedCode = {
+    val name = schema.getName
+    val enumSymbols = schema.getEnumSymbols.asScala
+    val ns = Option(schema.getNamespace).orElse(namespace)
+    val nsString = ns.getOrElse("")
+
+    val printer = new FunctionalPrinter()
+
+    val code = printer
+      .add("/** GENERATED CODE */")
+      .newline
+      .when(ns.isDefined)(_.add(s"package $nsString").newline)
+      .newline
+      .add(s"enum $name extends org.apache.avro.generic.GenericEnumSymbol[$name] {")
+      .indent
+      .add(s"case ${enumSymbols.mkString(", ")}")
+      .newline
+      .add(s"override def getSchema: org.apache.avro.Schema = $name.SCHEMA$$")
+      .add(s"override def compareTo(that: $name): Int = this.ordinal.compareTo(that.ordinal)")
+      .outdent
+      .add("}")
+      .newline
+      .add(s"object $name {")
+      .indent
+      .add(s"""val SCHEMA$$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse(\"${StringEscapeUtils.escapeJava(schema.toString)}\")""")
+      .newline
+      .add(s"def fromString(value: String): $name = valueOf(value)")
+      .outdent
+      .add("}")
+
+    GeneratedCode(s"${ns.map(_.replace(".", "/") + "/").getOrElse("")}$name.scala", code.result())
+  }
+}

--- a/avro2s/src/main/scala/avro2s/generator/specific/ScalaSpecificDataGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/ScalaSpecificDataGenerator.scala
@@ -1,0 +1,52 @@
+package avro2s.generator.specific
+
+import avro2s.generator.{FunctionalPrinter, GeneratedCode}
+import org.apache.avro.Schema
+
+private[avro2s] object ScalaSpecificDataGenerator {
+
+  val Namespace = "avro2s.generated"
+  val ClassName = "ScalaSpecificData"
+  val FullClassName = s"$Namespace.$ClassName"
+
+  def generate(enumSchemas: List[Schema]): GeneratedCode = {
+    val printer = new FunctionalPrinter()
+      .add("/** GENERATED CODE */")
+      .newline
+      .add(s"package $Namespace")
+      .newline
+      .add("import org.apache.avro.Schema")
+      .add("import org.apache.avro.specific.SpecificData")
+      .newline
+      .add(s"class $ClassName extends SpecificData {")
+      .indent
+      .add("override def createEnum(symbol: String, schema: Schema): AnyRef = {")
+      .indent
+      .add("schema.getFullName match {")
+      .indent
+
+    val withCases = enumSchemas.foldLeft(printer) { (p, s) =>
+      val fqn = s.getFullName
+      p.add(s"""case "$fqn" => $fqn.fromString(symbol)""")
+    }
+
+    val code = withCases
+      .add("case _ => super.createEnum(symbol, schema)")
+      .outdent
+      .add("}")
+      .outdent
+      .add("}")
+      .outdent
+      .add("}")
+      .newline
+      .add(s"object $ClassName {")
+      .indent
+      .add(s"private val instance = new $ClassName()")
+      .newline
+      .add(s"def get(): $ClassName = instance")
+      .outdent
+      .add("}")
+
+    GeneratedCode(s"avro2s/generated/$ClassName.scala", code.result())
+  }
+}

--- a/avro2s/src/main/scala/avro2s/generator/specific/SpecificGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/SpecificGenerator.scala
@@ -1,9 +1,11 @@
 package avro2s.generator.specific
 
 import avro2s.error.Error.SchemaError
+import avro2s.generator.generic.scala2.enumeration.GenericEnumGenerator.schemaToScala2Enum
+import avro2s.generator.generic.scala3.enumeration.GenericEnumGenerator.schemaToScala3Enum
 import avro2s.generator.javagenerator.JavaGenericEnumGenerator.schemaToJavaEnum
 import avro2s.generator.specific.scala2.fixed.SpecificFixedGenerator.schemaToScala2Fixed
-import avro2s.generator.{GeneratedCode, GeneratorConfig}
+import avro2s.generator.{EnumType, GeneratedCode, GeneratorConfig}
 import avro2s.language.ScalaVersion
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Type.{ENUM, FIXED, RECORD}
@@ -27,7 +29,7 @@ private[avro2s] class SpecificGenerator(generatorConfig: GeneratorConfig) {
   private def compileScala2(schema: Schema, namespace: Option[String]): GeneratedCode = {
     schema.getType match {
       case RECORD => schemaToScala2Record(schema, namespace)
-      case ENUM => schemaToJavaEnum(schema, namespace)
+      case ENUM => compileEnum(schema, namespace)
       case FIXED => schemaToScala2Fixed(schema, namespace)
       case _ => throw SchemaError("Only RECORD, or ENUM can be toplevel definitions")
     }
@@ -36,9 +38,17 @@ private[avro2s] class SpecificGenerator(generatorConfig: GeneratorConfig) {
   private def compileScala3(schema: Schema, namespace: Option[String]): GeneratedCode = {
     schema.getType match {
       case RECORD => schemaToScala3Record(schema, namespace)
-      case ENUM => schemaToJavaEnum(schema, namespace)
+      case ENUM => compileEnum(schema, namespace)
       case FIXED => schemaToScala2Fixed(schema, namespace)
       case _ => throw SchemaError("Only RECORD, or ENUM can be toplevel definitions")
+    }
+  }
+
+  private def compileEnum(schema: Schema, namespace: Option[String]): GeneratedCode = {
+    generatorConfig.enumType match {
+      case Some(EnumType.ScalaADT)   => schemaToScala2Enum(schema, namespace)
+      case Some(EnumType.Scala3Enum) => schemaToScala3Enum(schema, namespace)
+      case None                      => schemaToJavaEnum(schema, namespace)
     }
   }
 }

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala2/record/SpecificRecordGenerator.scala
@@ -2,9 +2,9 @@ package avro2s.generator.specific.scala2.record
 
 import avro2s.generator.logical.LogicalTypes
 import avro2s.generator.logical.LogicalTypes.LogicalTypeConverter
-import avro2s.generator.specific.SchemaLiteral
+import avro2s.generator.specific.{ScalaSpecificDataGenerator, SchemaLiteral}
 import avro2s.generator.specific.scala2.FieldOps._
-import avro2s.generator.{FunctionalPrinter, GeneratedCode, GeneratorConfig}
+import avro2s.generator.{EnumType, FunctionalPrinter, GeneratedCode, GeneratorConfig}
 import avro2s.schema.RecordInspector
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Type._
@@ -19,6 +19,11 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   private val typeHelpers = new TypeHelpers(ltc)
   import typeHelpers._
 
+  private val usesScalaEnums: Boolean = generatorConfig.enumType match {
+    case Some(EnumType.ScalaADT) | Some(EnumType.Scala3Enum) => true
+    case _ => false
+  }
+
   def schemaToScala2Record(schema: Schema, namespace: Option[String]): GeneratedCode = {
     val name = schema.getName
     val fields = schema.getFields.asScala.toList
@@ -27,6 +32,8 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
     val distinctConversions =
       if (!generatorConfig.logicalTypesEnabled) Nil
       else fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
+    val recordHasEnum = usesScalaEnums && recordReferencesEnum(schema)
+    val needsModel = distinctConversions.nonEmpty || recordHasEnum
 
     val functionalPrinter = new FunctionalPrinter()
 
@@ -44,7 +51,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .when(schema.getFields.toArray.length > 0)(_.add(toThis(fields)))
       .newline
       .add(s"override def getSchema: org.apache.avro.Schema = $name.SCHEMA$dollar")
-      .when(distinctConversions.nonEmpty)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
+      .when(needsModel)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
       .newline
       .add("override def get(field$: Int): AnyRef = {")
       .indent
@@ -78,11 +85,22 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add(s"object $name {")
       .indent
       .add(s"val SCHEMA$dollar: org.apache.avro.Schema = ${SchemaLiteral.parseExpression(schema.toString)}")
-      .call(printConversionInfrastructure(_, distinctConversions))
+      .call(printModelInfrastructure(_, distinctConversions, recordHasEnum))
       .outdent
       .add("}")
 
     GeneratedCode(s"${ns.map(_.replace(".", "/") + "/").getOrElse("") + name}.scala", code.result())
+  }
+
+  private def recordReferencesEnum(schema: Schema): Boolean = {
+    def refs(s: Schema): Boolean = s.getType match {
+      case ENUM => true
+      case UNION => s.getTypes.asScala.exists(refs)
+      case ARRAY => refs(s.getElementType)
+      case MAP => refs(s.getValueType)
+      case _ => false
+    }
+    schema.getFields.asScala.exists(f => refs(f.schema()))
   }
 
   private def printGetConversion(printer: FunctionalPrinter, name: String, fields: List[Schema.Field]): FunctionalPrinter = {
@@ -113,23 +131,33 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
     }
   }
 
-  private def printConversionInfrastructure(printer: FunctionalPrinter, distinctConversions: List[String]): FunctionalPrinter = {
-    if (distinctConversions.isEmpty) printer
-    else distinctConversions
-      .foldLeft(printer) { (p, cls) =>
+  private def printModelInfrastructure(printer: FunctionalPrinter, distinctConversions: List[String], recordHasEnum: Boolean): FunctionalPrinter = {
+    if (distinctConversions.isEmpty && !recordHasEnum) printer
+    else {
+      val baseCtor =
+        if (recordHasEnum) s"new ${ScalaSpecificDataGenerator.FullClassName}()"
+        else "new org.apache.avro.specific.SpecificData()"
+
+      val withVals = distinctConversions.foldLeft(printer) { (p, cls) =>
         val shortName = cls.split('.').last
         p.add(s"val $dollar$shortName: org.apache.avro.Conversion[_] = new $cls()")
       }
-      .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
-      .indent
-      .add("val model = new org.apache.avro.specific.SpecificData()")
-      .add(distinctConversions.map { cls =>
+
+      val modelBlock = withVals
+        .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
+        .indent
+        .add(s"val model = $baseCtor")
+
+      val withConversions = distinctConversions.foldLeft(modelBlock) { (p, cls) =>
         val shortName = cls.split('.').last
-        s"model.addLogicalTypeConversion($dollar$shortName)"
-      }: _*)
-      .add("model")
-      .outdent
-      .add("}")
+        p.add(s"model.addLogicalTypeConversion($dollar$shortName)")
+      }
+
+      withConversions
+        .add("model")
+        .outdent
+        .add("}")
+    }
   }
 
   private def fieldsToParams(fields: List[Schema.Field]): String = {
@@ -153,13 +181,13 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       case UNION => "None"
       case _ => "null"
     }
-    
+
     def logical(schema: Schema): Option[String] = {
       if (ltc.logicalTypeInUse(schema)) {
         Some(ltc.getDefault(schema))
       } else None
     }
-    
+
     s"def this() = this(${
       fields.map { f =>
         logical(f.schema()).getOrElse(defaultForSchema(f.schema()))

--- a/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
+++ b/avro2s/src/main/scala/avro2s/generator/specific/scala3/record/SpecificRecordGenerator.scala
@@ -3,8 +3,8 @@ package avro2s.generator.specific.scala3.record
 import avro2s.generator.logical.LogicalTypes
 import avro2s.generator.logical.LogicalTypes.LogicalTypeConverter
 import avro2s.generator.specific.scala3.FieldOps._
-import avro2s.generator.specific.SchemaLiteral
-import avro2s.generator.{FunctionalPrinter, GeneratedCode, GeneratorConfig}
+import avro2s.generator.specific.{ScalaSpecificDataGenerator, SchemaLiteral}
+import avro2s.generator.{EnumType, FunctionalPrinter, GeneratedCode, GeneratorConfig}
 import org.apache.avro.Schema
 import org.apache.avro.Schema.Type._
 
@@ -18,6 +18,11 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
   private val typeHelpers = new TypeHelpers(ltc)
   import typeHelpers._
 
+  private val usesScalaEnums: Boolean = generatorConfig.enumType match {
+    case Some(EnumType.ScalaADT) | Some(EnumType.Scala3Enum) => true
+    case _ => false
+  }
+
   def schemaToScala3Record(schema: Schema, namespace: Option[String]): GeneratedCode = {
     val name = schema.getName
     val fields = schema.getFields.asScala.toList
@@ -26,6 +31,8 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
     val distinctConversions =
       if (!generatorConfig.logicalTypesEnabled) Nil
       else fields.flatMap(f => ltc.collectConversionClasses(f.schema())).distinct
+    val recordHasEnum = usesScalaEnums && recordReferencesEnum(schema)
+    val needsModel = distinctConversions.nonEmpty || recordHasEnum
 
     val functionalPrinter = new FunctionalPrinter()
 
@@ -41,7 +48,7 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .when(schema.getFields.toArray.length > 0)(_.add(toThis(fields)))
       .newline
       .add(s"override def getSchema: org.apache.avro.Schema = $name.SCHEMA$dollar")
-      .when(distinctConversions.nonEmpty)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
+      .when(needsModel)(_.newline.add(s"override def getSpecificData(): org.apache.avro.specific.SpecificData = $name.MODEL$dollar"))
       .newline
       .add("override def get(field$: Int): AnyRef = {")
       .indent
@@ -75,11 +82,22 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
       .add(s"object $name {")
       .indent
       .add(s"val SCHEMA$dollar: org.apache.avro.Schema = ${SchemaLiteral.parseExpression(schema.toString)}")
-      .call(printConversionInfrastructure(_, distinctConversions))
+      .call(printModelInfrastructure(_, distinctConversions, recordHasEnum))
       .outdent
       .add("}")
 
     GeneratedCode(s"${ns.map(_.replace(".", "/") + "/").getOrElse("") + name}.scala", code.result())
+  }
+
+  private def recordReferencesEnum(schema: Schema): Boolean = {
+    def refs(s: Schema): Boolean = s.getType match {
+      case ENUM => true
+      case UNION => s.getTypes.asScala.exists(refs)
+      case ARRAY => refs(s.getElementType)
+      case MAP => refs(s.getValueType)
+      case _ => false
+    }
+    schema.getFields.asScala.exists(f => refs(f.schema()))
   }
 
   private def printGetConversion(printer: FunctionalPrinter, name: String, fields: List[Schema.Field]): FunctionalPrinter = {
@@ -110,23 +128,33 @@ private[avro2s] class SpecificRecordGenerator(generatorConfig: GeneratorConfig) 
     }
   }
 
-  private def printConversionInfrastructure(printer: FunctionalPrinter, distinctConversions: List[String]): FunctionalPrinter = {
-    if (distinctConversions.isEmpty) printer
-    else distinctConversions
-      .foldLeft(printer) { (p, cls) =>
+  private def printModelInfrastructure(printer: FunctionalPrinter, distinctConversions: List[String], recordHasEnum: Boolean): FunctionalPrinter = {
+    if (distinctConversions.isEmpty && !recordHasEnum) printer
+    else {
+      val baseCtor =
+        if (recordHasEnum) s"new ${ScalaSpecificDataGenerator.FullClassName}()"
+        else "new org.apache.avro.specific.SpecificData()"
+
+      val withVals = distinctConversions.foldLeft(printer) { (p, cls) =>
         val shortName = cls.split('.').last
         p.add(s"val $dollar$shortName: org.apache.avro.Conversion[?] = new $cls()")
       }
-      .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
-      .indent
-      .add("val model = new org.apache.avro.specific.SpecificData()")
-      .add(distinctConversions.map { cls =>
+
+      val modelBlock = withVals
+        .add(s"val MODEL$dollar: org.apache.avro.specific.SpecificData = {")
+        .indent
+        .add(s"val model = $baseCtor")
+
+      val withConversions = distinctConversions.foldLeft(modelBlock) { (p, cls) =>
         val shortName = cls.split('.').last
-        s"model.addLogicalTypeConversion($dollar$shortName)"
-      }: _*)
-      .add("model")
-      .outdent
-      .add("}")
+        p.add(s"model.addLogicalTypeConversion($dollar$shortName)")
+      }
+
+      withConversions
+        .add("model")
+        .outdent
+        .add("}")
+    }
   }
 
   private def fieldsToParams(fields: List[Schema.Field]): String = {

--- a/avro2s/src/test/resources/input/scala-enums/spec/enum-spec.avsc
+++ b/avro2s/src/test/resources/input/scala-enums/spec/enum-spec.avsc
@@ -1,0 +1,24 @@
+{
+  "type": "record",
+  "name": "EnumSpec",
+  "namespace": "avro2s.test.enums",
+  "fields": [
+    {
+      "name": "_enum",
+      "type": {
+        "type": "enum",
+        "name": "Suit",
+        "symbols": ["SPADES", "HEARTS", "DIAMONDS", "CLUBS"]
+      }
+    },
+    {
+      "name": "_optional_enum",
+      "type": ["null", "Suit"],
+      "default": null
+    },
+    {
+      "name": "_name",
+      "type": "string"
+    }
+  ]
+}

--- a/avro2s/src/test/scala-2.13/avro2s/generated/ScalaSpecificData.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generated/ScalaSpecificData.scala
@@ -1,0 +1,21 @@
+/** GENERATED CODE */
+
+package avro2s.generated
+
+import org.apache.avro.Schema
+import org.apache.avro.specific.SpecificData
+
+class ScalaSpecificData extends SpecificData {
+  override def createEnum(symbol: String, schema: Schema): AnyRef = {
+    schema.getFullName match {
+      case "avro2s.test.enums.Suit" => avro2s.test.enums.Suit.fromString(symbol)
+      case _ => super.createEnum(symbol, schema)
+    }
+  }
+}
+
+object ScalaSpecificData {
+  private val instance = new ScalaSpecificData()
+
+  def get(): ScalaSpecificData = instance
+}

--- a/avro2s/src/test/scala-2.13/avro2s/generator/CodeGeneratorTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/CodeGeneratorTest.scala
@@ -143,7 +143,7 @@ class CodeGeneratorTest extends AnyFunSuite with Matchers {
       s"""{"type":"record","name":"BigRecord","namespace":"test","doc":"$padding","fields":[{"name":"id","type":"string"}]}"""
     val schema = new org.apache.avro.Schema.Parser().parse(schemaJson)
     val schemaStore = new SchemaStore
-    val generatorConfig = GeneratorConfig(ScalaVersion.Scala_2_13, false)
+    val generatorConfig = GeneratorConfig(ScalaVersion.Scala_2_13, false, None)
 
     val results = CodeGenerator.generateCode(schema, schemaStore, generatorConfig)
 
@@ -172,18 +172,41 @@ class CodeGeneratorTest extends AnyFunSuite with Matchers {
     tripleQuotedSegments.foreach(seg => seg.length should be <= 65000)
   }
 
-  def generateCode(path: String, logicalTypesEnabled: Boolean = false): List[GeneratedCode] = {
-    val generatorConfig = GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled)
-    
+  test("scala ADT enums should produce expected output") {
+    val code = generateCode("input/scala-enums/spec/enum-spec.avsc", enumType = Some(EnumType.ScalaADT))
+
+    code.foreach { c =>
+      val name = c.path.split("/").last
+      val dir =
+        if (c.path.startsWith("avro2s/generated/")) "generated"
+        else "test/enums"
+      val expectedCode = Using(Source.fromFile(s"avro2s/src/test/scala-2.13/avro2s/$dir/$name"))(_.getLines.mkString("\n")).get
+      withClue(s"For path: ${c.path}") {
+        testResult(c, expectedCode)
+      }
+    }
+  }
+
+  test("scala ADT enums emit exactly one ScalaSpecificData") {
+    val code = generateCode("input/scala-enums/spec/enum-spec.avsc", enumType = Some(EnumType.ScalaADT))
+    val ssd = code.filter(_.path == "avro2s/generated/ScalaSpecificData.scala")
+    ssd should have length 1
+    ssd.head.code should include("""case "avro2s.test.enums.Suit" => avro2s.test.enums.Suit.fromString(symbol)""")
+  }
+
+  test("default (java enum) mode emits no ScalaSpecificData") {
+    val code = generateCode("input/scala-enums/spec/enum-spec.avsc", enumType = None)
+    code.exists(_.path == "avro2s/generated/ScalaSpecificData.scala") shouldBe false
+  }
+
+  def generateCode(path: String, logicalTypesEnabled: Boolean = false, enumType: Option[EnumType] = None): List[GeneratedCode] = {
+    val generatorConfig = GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled, enumType)
+
     val resourcePath = getClass.getClassLoader.getResource(path).getPath
     val file = new File(resourcePath)
     val schemas = new FileInputParser().getSchemas(file)
-    val schemaStore = new SchemaStore
 
-    for {
-      schema <- schemas
-      generatedCode <- CodeGenerator.generateCode(schema, schemaStore, generatorConfig)
-    } yield generatedCode
+    CodeGenerator.generateCode(schemas, generatorConfig)
   }
 
   private def loadTestCode(test: String, name: String): String = {

--- a/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/generator/SerializationTest.scala
@@ -5,6 +5,7 @@ import avro2s.test.maps.{Maps, Record => MapRecord}
 import avro2s.test.namespaces.explicit._
 import avro2s.test.namespaces.{Namespaces, RecordWithInheritedNamespace, RecordWithNamespaceInheritedFromIndirectParent}
 import avro2s.test.records.EmptyRecord
+import avro2s.test.enums.{EnumSpec, Suit => EnumSuit}
 import avro2s.test.spec.{AvroSpec, Suit, md5}
 import avro2s.test.unions.Unions
 import org.scalatest.funsuite.AnyFunSuite
@@ -393,8 +394,39 @@ class SerializationTest extends AnyFunSuite with Matchers {
       _empty_record = EmptyRecord(),
       _int = 5
     )
-    
+
     val serialized = serialize(emptyRecords)
     deserialize[avro2s.test.records.EmptyRecords](serialized, emptyRecords.getSchema) shouldBe emptyRecords
+  }
+
+  test("scala ADT enum field can be serialized and deserialized") {
+    val spec = EnumSpec(_enum = EnumSuit.SPADES, _optional_enum = Some(EnumSuit.HEARTS), _name = "hello")
+    deserializeWithModel[EnumSpec](serialize(spec), spec.getSchema, EnumSpec.MODEL$) shouldBe spec
+  }
+
+  test("scala ADT enum optional field with None can be round-tripped") {
+    val spec = EnumSpec(_enum = EnumSuit.CLUBS, _optional_enum = None, _name = "nope")
+    deserializeWithModel[EnumSpec](serialize(spec), spec.getSchema, EnumSpec.MODEL$) shouldBe spec
+  }
+
+  test("scala ADT enum all symbols round-trip") {
+    Seq(EnumSuit.SPADES, EnumSuit.HEARTS, EnumSuit.DIAMONDS, EnumSuit.CLUBS).foreach { s =>
+      val spec = EnumSpec(_enum = s, _optional_enum = Some(s), _name = "x")
+      deserializeWithModel[EnumSpec](serialize(spec), spec.getSchema, EnumSpec.MODEL$) shouldBe spec
+    }
+  }
+
+  test("scala ADT enum fromString rejects unknown symbols") {
+    an[IllegalArgumentException] shouldBe thrownBy(EnumSuit.fromString("JOKER"))
+  }
+
+  test("EnumSpec.getSpecificData returns the ScalaSpecificData-backed MODEL$") {
+    val data = EnumSpec.MODEL$
+    data.getClass.getName shouldBe "avro2s.generated.ScalaSpecificData"
+  }
+
+  test("EnumSpec record instance returns same MODEL$ via getSpecificData override") {
+    val spec = EnumSpec(_enum = EnumSuit.SPADES, _optional_enum = None, _name = "x")
+    spec.getSpecificData() should be theSameInstanceAs EnumSpec.MODEL$
   }
 }

--- a/avro2s/src/test/scala-2.13/avro2s/test/enums/EnumSpec.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/enums/EnumSpec.scala
@@ -1,0 +1,47 @@
+/** GENERATED CODE */
+
+package avro2s.test.enums
+
+import scala.annotation.switch
+
+case class EnumSpec(var _enum: avro2s.test.enums.Suit, var _optional_enum: Option[avro2s.test.enums.Suit], var _name: String) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(null, None, "")
+
+  override def getSchema: org.apache.avro.Schema = EnumSpec.SCHEMA$
+
+  override def getSpecificData(): org.apache.avro.specific.SpecificData = EnumSpec.MODEL$
+
+  override def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => _enum.asInstanceOf[AnyRef]
+      case 1 => _optional_enum match {
+        case None => null
+        case Some(x) => x.asInstanceOf[AnyRef]
+      }
+      case 2 => _name.asInstanceOf[AnyRef]
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this._enum = value.asInstanceOf[avro2s.test.enums.Suit]
+      case 1 => this._optional_enum = {
+        value match {
+          case null => None
+          case x: avro2s.test.enums.Suit => Some(x)
+        }
+      }
+      case 2 => this._name = value.toString.asInstanceOf[String]
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+}
+
+object EnumSpec {
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"EnumSpec","namespace":"avro2s.test.enums","fields":[{"name":"_enum","type":{"type":"enum","name":"Suit","symbols":["SPADES","HEARTS","DIAMONDS","CLUBS"]}},{"name":"_optional_enum","type":["null","Suit"],"default":null},{"name":"_name","type":"string"}]}""")
+  val MODEL$: org.apache.avro.specific.SpecificData = {
+    val model = new avro2s.generated.ScalaSpecificData()
+    model
+  }
+}

--- a/avro2s/src/test/scala-2.13/avro2s/test/enums/Suit.scala
+++ b/avro2s/src/test/scala-2.13/avro2s/test/enums/Suit.scala
@@ -1,0 +1,30 @@
+/** GENERATED CODE */
+
+package avro2s.test.enums
+
+
+sealed abstract class Suit(val value: String, val ordinal: Int) extends org.apache.avro.generic.GenericEnumSymbol[Suit] {
+  override def getSchema: org.apache.avro.Schema = Suit.SCHEMA$
+  override def compareTo(that: Suit): Int = this.ordinal.compareTo(that.ordinal)
+}
+
+object Suit {
+  case object SPADES extends Suit("SPADES", 0)
+  case object HEARTS extends Suit("HEARTS", 1)
+  case object DIAMONDS extends Suit("DIAMONDS", 2)
+  case object CLUBS extends Suit("CLUBS", 3)
+
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("{\"type\":\"enum\",\"name\":\"Suit\",\"namespace\":\"avro2s.test.enums\",\"symbols\":[\"SPADES\",\"HEARTS\",\"DIAMONDS\",\"CLUBS\"]}")
+
+  def fromString(value: String): Suit = value match {
+    case "SPADES" => SPADES
+    case "HEARTS" => HEARTS
+    case "DIAMONDS" => DIAMONDS
+    case "CLUBS" => CLUBS
+    case other => throw new IllegalArgumentException(s"Unknown enum value: $other")
+  }
+
+  def valueOf(value: String): Suit = fromString(value)
+
+  val values: Seq[Suit] = Seq(SPADES, HEARTS, DIAMONDS, CLUBS)
+}

--- a/avro2s/src/test/scala-3/avro2s/generated/ScalaSpecificData.scala
+++ b/avro2s/src/test/scala-3/avro2s/generated/ScalaSpecificData.scala
@@ -1,0 +1,21 @@
+/** GENERATED CODE */
+
+package avro2s.generated
+
+import org.apache.avro.Schema
+import org.apache.avro.specific.SpecificData
+
+class ScalaSpecificData extends SpecificData {
+  override def createEnum(symbol: String, schema: Schema): AnyRef = {
+    schema.getFullName match {
+      case "avro2s.test.enums.Suit" => avro2s.test.enums.Suit.fromString(symbol)
+      case _ => super.createEnum(symbol, schema)
+    }
+  }
+}
+
+object ScalaSpecificData {
+  private val instance = new ScalaSpecificData()
+
+  def get(): ScalaSpecificData = instance
+}

--- a/avro2s/src/test/scala-3/avro2s/generator/CodeGeneratorTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/CodeGeneratorTest.scala
@@ -152,7 +152,7 @@ class CodeGeneratorTest extends AnyFunSuite with Matchers {
       s"""{"type":"record","name":"BigRecord","namespace":"test","doc":"$padding","fields":[{"name":"id","type":"string"}]}"""
     val schema = new org.apache.avro.Schema.Parser().parse(schemaJson)
     val schemaStore = new SchemaStore
-    val generatorConfig = GeneratorConfig(ScalaVersion.Scala_3, false)
+    val generatorConfig = GeneratorConfig(ScalaVersion.Scala_3, false, None)
 
     val results = CodeGenerator.generateCode(schema, schemaStore, generatorConfig)
 
@@ -181,18 +181,41 @@ class CodeGeneratorTest extends AnyFunSuite with Matchers {
     tripleQuotedSegments.foreach(seg => seg.length should be <= 65000)
   }
 
-  def generateCode(path: String, logicalTypesEnabled: Boolean = false): List[GeneratedCode] = {
-    val generatorConfig = GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled)
+  test("scala 3 enums should produce expected output") {
+    val code = generateCode("input/scala-enums/spec/enum-spec.avsc", enumType = Some(EnumType.Scala3Enum))
+
+    code.foreach { c =>
+      val name = c.path.split("/").last
+      val dir =
+        if (c.path.startsWith("avro2s/generated/")) "generated"
+        else "test/enums"
+      val expectedCode = Using(Source.fromFile(s"avro2s/src/test/scala-3/avro2s/$dir/$name"))(_.getLines.mkString("\n")).get
+      withClue(s"For path: ${c.path}") {
+        testResult(c, expectedCode)
+      }
+    }
+  }
+
+  test("scala 3 enums emit exactly one ScalaSpecificData") {
+    val code = generateCode("input/scala-enums/spec/enum-spec.avsc", enumType = Some(EnumType.Scala3Enum))
+    val ssd = code.filter(_.path == "avro2s/generated/ScalaSpecificData.scala")
+    ssd should have length 1
+    ssd.head.code should include("""case "avro2s.test.enums.Suit" => avro2s.test.enums.Suit.fromString(symbol)""")
+  }
+
+  test("default (java enum) mode emits no ScalaSpecificData") {
+    val code = generateCode("input/scala-enums/spec/enum-spec.avsc", enumType = None)
+    code.exists(_.path == "avro2s/generated/ScalaSpecificData.scala") shouldBe false
+  }
+
+  def generateCode(path: String, logicalTypesEnabled: Boolean = false, enumType: Option[EnumType] = None): List[GeneratedCode] = {
+    val generatorConfig = GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled, enumType)
 
     val resourcePath = getClass.getClassLoader.getResource(path).getPath
     val file = new File(resourcePath)
     val schemas = new FileInputParser().getSchemas(file)
-    val schemaStore = new SchemaStore
 
-    for {
-      schema <- schemas
-      generatedCode <- CodeGenerator.generateCode(schema, schemaStore, generatorConfig)
-    } yield generatedCode
+    CodeGenerator.generateCode(schemas, generatorConfig)
   }
 
   private def loadTestCode(test: String, name: String): String = {

--- a/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
+++ b/avro2s/src/test/scala-3/avro2s/generator/SerializationTest.scala
@@ -6,6 +6,7 @@ import avro2s.test.arrays.{Arrays, Record => ArrayRecord, Record1 => ArrayRecord
 import avro2s.test.maps.{Maps, Record => MapRecord}
 import avro2s.test.namespaces.{Namespaces, RecordWithInheritedNamespace, RecordWithNamespaceInheritedFromIndirectParent}
 import avro2s.test.namespaces.explicit.{RecordWithExplicitNamespace, RecordWithNamespaceInheritedFromDirectParent, RecordWithNamespaceInheritedFromIndirectNonTopLevelParent, RecordWithNamespaceInheritedViaArray, RecordWithNamespaceInheritedViaMap, RecordWithNamespaceInheritedViaUnion}
+import avro2s.test.enums.{EnumSpec, Suit => EnumSuit}
 import avro2s.test.spec.{AvroSpec, Suit, md5}
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -372,5 +373,36 @@ class SerializationTest extends AnyFunSuite with Matchers {
 
     val serialized = serialize(emptyRecords)
     deserialize[avro2s.test.records.EmptyRecords](serialized, emptyRecords.getSchema) shouldBe emptyRecords
+  }
+
+  test("scala 3 enum field can be serialized and deserialized") {
+    val spec = EnumSpec(_enum = EnumSuit.SPADES, _optional_enum = Some(EnumSuit.HEARTS), _name = "hello")
+    deserializeWithModel[EnumSpec](serialize(spec), spec.getSchema, EnumSpec.MODEL$) shouldBe spec
+  }
+
+  test("scala 3 enum optional field with None can be round-tripped") {
+    val spec = EnumSpec(_enum = EnumSuit.CLUBS, _optional_enum = None, _name = "nope")
+    deserializeWithModel[EnumSpec](serialize(spec), spec.getSchema, EnumSpec.MODEL$) shouldBe spec
+  }
+
+  test("scala 3 enum all symbols round-trip") {
+    Seq(EnumSuit.SPADES, EnumSuit.HEARTS, EnumSuit.DIAMONDS, EnumSuit.CLUBS).foreach { s =>
+      val spec = EnumSpec(_enum = s, _optional_enum = Some(s), _name = "x")
+      deserializeWithModel[EnumSpec](serialize(spec), spec.getSchema, EnumSpec.MODEL$) shouldBe spec
+    }
+  }
+
+  test("scala 3 enum fromString rejects unknown symbols") {
+    an[IllegalArgumentException] shouldBe thrownBy(EnumSuit.fromString("JOKER"))
+  }
+
+  test("EnumSpec.getSpecificData returns the ScalaSpecificData-backed MODEL$") {
+    val data = EnumSpec.MODEL$
+    data.getClass.getName shouldBe "avro2s.generated.ScalaSpecificData"
+  }
+
+  test("EnumSpec record instance returns same MODEL$ via getSpecificData override") {
+    val spec = EnumSpec(_enum = EnumSuit.SPADES, _optional_enum = None, _name = "x")
+    spec.getSpecificData() should be theSameInstanceAs EnumSpec.MODEL$
   }
 }

--- a/avro2s/src/test/scala-3/avro2s/test/enums/EnumSpec.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/enums/EnumSpec.scala
@@ -1,0 +1,52 @@
+/** GENERATED CODE */
+
+package avro2s.test.enums
+
+import scala.annotation.switch
+
+case class EnumSpec(var _enum: avro2s.test.enums.Suit, var _optional_enum: Option[avro2s.test.enums.Suit], var _name: String) extends org.apache.avro.specific.SpecificRecordBase {
+  def this() = this(null, None, "")
+
+  override def getSchema: org.apache.avro.Schema = EnumSpec.SCHEMA$
+
+  override def getSpecificData(): org.apache.avro.specific.SpecificData = EnumSpec.MODEL$
+
+  override def get(field$: Int): AnyRef = {
+    (field$: @switch) match {
+      case 0 => _enum.asInstanceOf[AnyRef]
+      case 1 => _optional_enum match {
+        case Some(x: avro2s.test.enums.Suit) => x.asInstanceOf[AnyRef]
+        case None => null.asInstanceOf[AnyRef]
+      }
+      case 2 => _name.asInstanceOf[AnyRef]
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+
+  override def put(field$: Int, value: Any): Unit = {
+    (field$: @switch) match {
+      case 0 => this._enum = {
+        value.asInstanceOf[avro2s.test.enums.Suit]
+      }
+      case 1 => this._optional_enum = {
+        value match {
+          case null => None
+          case x: avro2s.test.enums.Suit => Option(x.asInstanceOf[avro2s.test.enums.Suit])
+          case _ => throw new org.apache.avro.AvroRuntimeException("Unexpected type: " + value.getClass.getName)
+        }
+      }
+      case 2 => this._name = {
+        value.toString.asInstanceOf[String]
+      }
+      case _ => throw new org.apache.avro.AvroRuntimeException("Bad index")
+    }
+  }
+}
+
+object EnumSpec {
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("""{"type":"record","name":"EnumSpec","namespace":"avro2s.test.enums","fields":[{"name":"_enum","type":{"type":"enum","name":"Suit","symbols":["SPADES","HEARTS","DIAMONDS","CLUBS"]}},{"name":"_optional_enum","type":["null","Suit"],"default":null},{"name":"_name","type":"string"}]}""")
+  val MODEL$: org.apache.avro.specific.SpecificData = {
+    val model = new avro2s.generated.ScalaSpecificData()
+    model
+  }
+}

--- a/avro2s/src/test/scala-3/avro2s/test/enums/Suit.scala
+++ b/avro2s/src/test/scala-3/avro2s/test/enums/Suit.scala
@@ -1,0 +1,17 @@
+/** GENERATED CODE */
+
+package avro2s.test.enums
+
+
+enum Suit extends org.apache.avro.generic.GenericEnumSymbol[Suit] {
+  case SPADES, HEARTS, DIAMONDS, CLUBS
+
+  override def getSchema: org.apache.avro.Schema = Suit.SCHEMA$
+  override def compareTo(that: Suit): Int = this.ordinal.compareTo(that.ordinal)
+}
+
+object Suit {
+  val SCHEMA$: org.apache.avro.Schema = new org.apache.avro.Schema.Parser().parse("{\"type\":\"enum\",\"name\":\"Suit\",\"namespace\":\"avro2s.test.enums\",\"symbols\":[\"SPADES\",\"HEARTS\",\"DIAMONDS\",\"CLUBS\"]}")
+
+  def fromString(value: String): Suit = valueOf(value)
+}

--- a/avro2s/src/test/scala/RegenerateTestCode.scala
+++ b/avro2s/src/test/scala/RegenerateTestCode.scala
@@ -1,4 +1,4 @@
-import avro2s.generator.{CodeGenerator, GeneratorConfig}
+import avro2s.generator.{CodeGenerator, EnumType, GeneratorConfig}
 import avro2s.language.ScalaVersion
 
 object RegenerateTestCode extends App {
@@ -6,37 +6,49 @@ object RegenerateTestCode extends App {
   CodeGenerator.generateCode(
     "avro2s/src/test/resources/input/default",
     "avro2s/src/test/scala-2.13",
-    GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled = false)
+    GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled = false, enumType = None)
   )
 
   CodeGenerator.generateCode(
     "avro2s/src/test/resources/input/scala-2.13",
     "avro2s/src/test/scala-2.13",
-    GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled = false)
+    GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled = false, enumType = None)
   )
 
   CodeGenerator.generateCode(
     "avro2s/src/test/resources/input/logical-enabled",
     "avro2s/src/test/scala-2.13",
-    GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled = true)
+    GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled = true, enumType = None)
   )
-  
+
+  CodeGenerator.generateCode(
+    "avro2s/src/test/resources/input/scala-enums",
+    "avro2s/src/test/scala-2.13",
+    GeneratorConfig(ScalaVersion.Scala_2_13, logicalTypesEnabled = false, enumType = Some(EnumType.ScalaADT))
+  )
+
   // Regenerate test code for Scala 3
   CodeGenerator.generateCode(
     "avro2s/src/test/resources/input/default",
     "avro2s/src/test/scala-3",
-    GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled = false)
+    GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled = false, enumType = None)
   )
 
   CodeGenerator.generateCode(
     "avro2s/src/test/resources/input/scala-3",
     "avro2s/src/test/scala-3",
-    GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled = false)
+    GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled = false, enumType = None)
   )
 
   CodeGenerator.generateCode(
     "avro2s/src/test/resources/input/logical-enabled",
     "avro2s/src/test/scala-3",
-    GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled = true)
+    GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled = true, enumType = None)
+  )
+
+  CodeGenerator.generateCode(
+    "avro2s/src/test/resources/input/scala-enums",
+    "avro2s/src/test/scala-3",
+    GeneratorConfig(ScalaVersion.Scala_3, logicalTypesEnabled = false, enumType = Some(EnumType.Scala3Enum))
   )
 }

--- a/avro2s/src/test/scala/avro2s/generator/specific/ScalaSpecificDataGeneratorTest.scala
+++ b/avro2s/src/test/scala/avro2s/generator/specific/ScalaSpecificDataGeneratorTest.scala
@@ -1,0 +1,42 @@
+package avro2s.generator.specific
+
+import org.apache.avro.Schema
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class ScalaSpecificDataGeneratorTest extends AnyFunSuite with Matchers {
+
+  test("emits a case arm per enum schema and a fallback") {
+    val suit = new Schema.Parser().parse(
+      """{"type":"enum","name":"Suit","namespace":"a.b","symbols":["SPADES","HEARTS"]}"""
+    )
+    val direction = new Schema.Parser().parse(
+      """{"type":"enum","name":"Direction","namespace":"x.y","symbols":["NORTH","SOUTH"]}"""
+    )
+
+    val gc = ScalaSpecificDataGenerator.generate(List(suit, direction))
+
+    gc.path shouldBe "avro2s/generated/ScalaSpecificData.scala"
+    gc.code should include("class ScalaSpecificData extends SpecificData")
+    gc.code should include("""case "a.b.Suit" => a.b.Suit.fromString(symbol)""")
+    gc.code should include("""case "x.y.Direction" => x.y.Direction.fromString(symbol)""")
+    gc.code should include("case _ => super.createEnum(symbol, schema)")
+  }
+
+  test("emits only fallback for empty input") {
+    val gc = ScalaSpecificDataGenerator.generate(Nil)
+    gc.code should include("case _ => super.createEnum(symbol, schema)")
+    gc.code should not include "fromString(symbol)"
+  }
+
+  test("singleton accessor present") {
+    val gc = ScalaSpecificDataGenerator.generate(Nil)
+    gc.code should include("def get(): ScalaSpecificData = instance")
+  }
+
+  test("handles enum without a namespace") {
+    val noNs = new Schema.Parser().parse("""{"type":"enum","name":"Status","symbols":["ON","OFF"]}""")
+    val gc = ScalaSpecificDataGenerator.generate(List(noNs))
+    gc.code should include("""case "Status" => Status.fromString(symbol)""")
+  }
+}

--- a/avro2s/src/test/scala/avro2s/serialization/SerializationHelpers.scala
+++ b/avro2s/src/test/scala/avro2s/serialization/SerializationHelpers.scala
@@ -40,4 +40,10 @@ object SerializationHelpers {
     val decoder: BinaryDecoder = DecoderFactory.get().binaryDecoder(bytes, null)
     reader.read(null.asInstanceOf[T], decoder)
   }
+
+  def deserializeWithModel[T <: SpecificRecordBase](bytes: Array[Byte], schema: Schema, model: SpecificData): T = {
+    val reader = new SpecificDatumReader[T](schema, schema, model)
+    val decoder: BinaryDecoder = DecoderFactory.get().binaryDecoder(bytes, null)
+    reader.read(null.asInstanceOf[T], decoder)
+  }
 }

--- a/sbt-avro2s/src/main/scala/avro2s/plugin/Avro2sPlugin.scala
+++ b/sbt-avro2s/src/main/scala/avro2s/plugin/Avro2sPlugin.scala
@@ -1,6 +1,6 @@
 package avro2s.plugin
 
-import avro2s.generator.{CodeGenerator, GeneratorConfig}
+import avro2s.generator.{CodeGenerator, EnumType, GeneratorConfig}
 import sbt.Keys.*
 import sbt.internal.util.ManagedLogger
 import sbt.*
@@ -18,12 +18,14 @@ object Avro2sPlugin extends AutoPlugin {
     lazy val avro2sGeneratedScalaTarget = settingKey[File]("Scala source directory for compiled avro")
     lazy val avro2sGeneratedAvscTarget  = settingKey[File]("Target for storing 'avsc' files generated from avro2sSchemaSource 'avdl' files")
     lazy val avro2sLogicalTypesEnabled = settingKey[Boolean]("Whether to enable avro2s logical types")
+    lazy val avro2sEnumType = settingKey[Option[EnumType]]("Enum generation strategy: None = Java enum (default), Some(EnumType.ScalaADT) = Scala 2.13 sealed ADT, Some(EnumType.Scala3Enum) = Scala 3 native enum")
 
     lazy val defaultSettings: Seq[Setting[?]] = Seq(
       avro2sSchemaSource := sourceDirectory.value / "avro",
       avro2sGeneratedAvscTarget := target.value / "avro2s" / "generated" / "avsc",
       avro2sGeneratedScalaTarget := (Compile / sourceManaged).value / "compiled_avro",
-      avro2sLogicalTypesEnabled := true
+      avro2sLogicalTypesEnabled := true,
+      avro2sEnumType := None
     )
   }
 
@@ -47,6 +49,7 @@ object Avro2sPlugin extends AutoPlugin {
     val generatorConfig  = GeneratorConfig(
       avro2s.language.ScalaVersion.fromString(scalaBinaryVersion.value),
       logicalTypesEnabled = avro2sLogicalTypesEnabled.value,
+      enumType = avro2sEnumType.value,
     )
 
     AvdlCodeGenerator.generateCode( // Generate AVDL derived code


### PR DESCRIPTION
## Summary

Generates idiomatic Scala 2.13 sealed-ADT or Scala 3 native `enum` types from Avro enum schemas while preserving Avro wire compatibility. Opt-in via a new `avro2sEnumType` sbt setting.

Supersedes #27 — same conceptual design (override `SpecificData.createEnum` in a custom `SpecificData`), but replaces the per-call reflection bridge (`Class.forName(name + "$").getField("MODULE$").getMethod("fromString").invoke(...)`) with **compile-time direct dispatch** generated from the set of enum schemas seen during a generation run.

## What changed

- New `EnumType` ADT with `ScalaADT` (Scala 2.13 sealed abstract class with case objects) and `Scala3Enum` (native enum) case objects
- New `avro2sEnumType: SettingKey[Option[EnumType]]` in `Avro2sPlugin`. Default `None` = current Java enum behaviour
- New per-run `avro2s.generated.ScalaSpecificData` containing a closed pattern match over schema full names dispatching to each generated enum's companion `fromString`
- Unified per-record `MODEL$` — records with logical-type conversions and/or Scala enum fields share one `getSpecificData` override path. When both are present, `MODEL$` is built on top of `ScalaSpecificData` with conversions added on
- `GeneratorConfig.enumType` is a required parameter (no default), matching the project's no-default-args convention

## Tests

- `CodeGeneratorTest` — string comparison against pre-generated expected files (both Scala 2.13 and Scala 3, both `ScalaADT` and `Scala3Enum`), plus assertions that exactly one `ScalaSpecificData` is emitted per run and that default mode emits none
- `SerializationTest` — round-trip tests per Scala version (direct enum field, optional-enum None, all symbols, unknown-symbol rejection), plus wiring assertions that `EnumSpec.MODEL$` and `EnumSpec(...).getSpecificData()` return the `ScalaSpecificData`-backed instance
- `ScalaSpecificDataGeneratorTest` — unit-level coverage of the generator output, including empty input and namespace-less enums
- All 120+ existing tests pass unchanged across Scala 2.12.20, 2.13.16, 3.3.6

## Architecturally questionable decisions / shortcuts

These are deliberate but worth flagging for review:

1. **`SpecificDatumReader(schema)` does not auto-discover `MODEL$`.** Avro's `SpecificData.getForSchema(schema)` looks for `MODEL$` as a Java static field on the main class via `getDeclaredField`. Scala compiles `val MODEL$` in a companion object as a field on the companion class (`X$`), not on `X` itself, so Avro doesn't find it and falls back to the default `SpecificData` whose `createEnum` calls `Enum.valueOf` (which fails for Scala enums). **Workaround:** users must construct their reader with `MODEL$` explicitly (`new SpecificDatumReader[X](X.SCHEMA$, X.SCHEMA$, X.MODEL$)`). Documented in the README. A future improvement could codegen `@scala.annotation.static val MODEL$` to surface it as a Java static, but `@static` has restrictions on initializer shape (block expressions, references to companion members) that would need verifying across Scala 2.13 and 3.

2. **Conversions list ordering for combined logical+enum records is untested.** The unified `MODEL$` design supports records containing both logical-type fields and Scala enum fields, but no fixture exercises that combination today. The code path is straightforward (`new ScalaSpecificData()` instead of `new SpecificData()` as the base, then add conversions as before), but a combined fixture test would lock the behavior in.

3. **`avro2s.generated` namespace is reserved.** The generated `ScalaSpecificData` lives in `avro2s.generated`. If a downstream project happens to also write code into that package, there will be a collision. Low risk in practice but worth documenting if you want to make this stricter.

4. **Test helper has default arguments** (`logicalTypesEnabled: Boolean = false`, `enumType: Option[EnumType] = None` in `CodeGeneratorTest.generateCode`). This technically deviates from the project's no-default-args convention, but only in test code where it keeps existing test sites terse. The production `GeneratorConfig` is strict — no defaults.

5. **`fromString` contract is implicit.** The codegen registry assumes every generated Scala enum's companion has `fromString(String): EnumType`. Both Scala 2.13 and Scala 3 generators emit this method, but it's a convention enforced only by `ScalaSpecificData` failing to compile if the method goes missing — not by a trait or compile-time check. If you'd prefer a trait that the companion implements, that's a follow-up.

6. **Scala 3 enum's `fromString` delegates to compiler-generated `valueOf`.** Both throw `IllegalArgumentException` for unknown symbols, so behavior is identical to the Scala 2.13 hand-written variant. No drift, but it's worth knowing the implementations differ at the source level.

## Test plan

- [x] Existing tests pass unchanged across Scala 2.12.20, 2.13.16, 3.3.6
- [x] New codegen comparison tests verify byte-for-byte expected output
- [x] New serialization round-trips verify wire-compatible deserialization through `ScalaSpecificData`
- [x] `RegenerateTestCode` updated; expected files are checked in

🤖 Generated with [Claude Code](https://claude.com/claude-code)